### PR TITLE
Caching now() is removed

### DIFF
--- a/geo_fence_operations/serializers.py
+++ b/geo_fence_operations/serializers.py
@@ -16,10 +16,8 @@ class GeoFencePropertiesSerializer(serializers.Serializer):
     name = serializers.CharField(required=False, default="Standard Geofence")
     upper_limit = serializers.IntegerField(required=False, default=500)
     lower_limit = serializers.IntegerField(required=False, default=100)
-    start_time = serializers.DateField(required=False, default=arrow.now().isoformat())
-    end_time = serializers.DateField(
-        required=False, default=arrow.now().shift(hours=1).isoformat()
-    )
+    start_time = serializers.DateField(required=False)
+    end_time = serializers.DateField(required=False)
 
 
 class GeoFenceFeatureSerializer(serializers.Serializer):

--- a/geo_fence_operations/views.py
+++ b/geo_fence_operations/views.py
@@ -86,11 +86,16 @@ def set_geo_fence(request: HttpRequest):
     bnd_tuple = combined_features.bounds
     bounds = ",".join(["{:.7f}".format(x) for x in bnd_tuple])
 
-    s_time = feature["properties"]["start_time"]
-    start_time = arrow.get(s_time).isoformat()
-
-    e_time = feature["properties"]["end_time"]
-    end_time = arrow.get(e_time).isoformat()
+    start_time = (
+        arrow.now().isoformat()
+        if "start_time" not in feature["properties"]
+        else arrow.get(feature["properties"]["start_time"]).isoformat()
+    )
+    end_time = (
+        arrow.now().shift(hours=1).isoformat()
+        if "end_time" not in feature["properties"]
+        else arrow.get(feature["properties"]["end_time"]).isoformat()
+    )
 
     upper_limit = Decimal(feature["properties"]["upper_limit"])
     lower_limit = Decimal(feature["properties"]["lower_limit"])


### PR DESCRIPTION
## Proposed changes

DRF Serializer class is **instantiating only once** during an API session. This makes it impossible to set `now()` as the default for **datetime fields**. Hence moved settings now() form Serializing to **Views** logic.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with the changes
- [ ] Added new tests that prove the changes in this PR works
- [ ] Added necessary documentation (if appropriate)
- [ ] Added copyrights to new files (if appropriate)

## Further comments