### PR TITLE
Added time consideration to the datetime filter, Added new filter min_alt&max_alt

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,92 @@
+import datetime
+import json
+
+import pytest
+
+from flight_declaration_operations import models as fdo_models
+
+
+@pytest.mark.django_db
+@pytest.fixture(scope="function")
+def create_flight_plan(db) -> fdo_models.FlightDeclaration:
+    flight_time = (datetime.datetime.now() + datetime.timedelta(days=1)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    max_alt = 100
+    min_alt = 90
+    return fdo_models.FlightDeclaration.objects.create(
+        operational_intent={
+            "volumes": [
+                {
+                    "volume": {
+                        "outline_polygon": {
+                            "vertices": [
+                                {
+                                    "lat": 3.0000070710678117,
+                                    "lng": 1.999992928932188,
+                                },
+                                {
+                                    "lat": 3.000007730104534,
+                                    "lng": 1.9999936560671583,
+                                },
+                                {
+                                    "lat": 2.0000070710678117,
+                                    "lng": 0.9999929289321882,
+                                },
+                            ]
+                        },
+                        "altitude_lower": {
+                            "value": min_alt,
+                            "reference": "W84",
+                            "units": "M",
+                        },
+                        "altitude_upper": {
+                            "value": max_alt,
+                            "reference": "W84",
+                            "units": "M",
+                        },
+                        "outline_circle": None,
+                    },
+                    "time_start": {
+                        "format": "RFC3339",
+                        "value": "2023-07-26T15:00:00+00:00",
+                    },
+                    "time_end": {
+                        "format": "RFC3339",
+                        "value": "2023-07-26T16:00:00+00:00",
+                    },
+                }
+            ],
+            "priority": 0,
+            "state": "Accepted",
+            "off_nominal_volumes": [],
+        },
+        bounds="",
+        type_of_operation=1,
+        submitted_by="Test user",
+        is_approved=False,
+        start_datetime=flight_time,
+        end_datetime=flight_time,
+        originating_party="Test Organizer",
+        flight_declaration_raw_geojson=json.dumps(
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "properties": {
+                            "id": "0",
+                            "start_datetime": "2023-08-10T16:29:08.842Z",
+                            "end_datetime": "2023-08-10T19:29:08.842Z",
+                            "max_altitude": {"meters": max_alt, "datum": "agl"},
+                            "min_altitude": {"meters": min_alt, "datum": "agl"},
+                        },
+                        "geometry": {
+                            "coordinates": [[1, 2], [2, 3]],
+                            "type": "LineString",
+                        },
+                    }
+                ],
+            }
+        ),
+    )

--- a/conftest.py
+++ b/conftest.py
@@ -8,13 +8,13 @@ from flight_declaration_operations import models as fdo_models
 
 @pytest.mark.django_db
 @pytest.fixture(scope="function")
-def create_flight_plan(db) -> fdo_models.FlightDeclaration:
-    flight_time = (datetime.datetime.now() + datetime.timedelta(days=1)).strftime(
-        "%Y-%m-%dT%H:%M:%SZ"
-    )
+def create_flight_plan(db) -> None:
+    flight_time = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Flight plan 1
     max_alt = 100
     min_alt = 90
-    return fdo_models.FlightDeclaration.objects.create(
+    fdo_models.FlightDeclaration.objects.create(
         operational_intent={
             "volumes": [
                 {
@@ -63,11 +63,11 @@ def create_flight_plan(db) -> fdo_models.FlightDeclaration:
         },
         bounds="",
         type_of_operation=1,
-        submitted_by="Test user",
+        submitted_by="User 001",
         is_approved=False,
         start_datetime=flight_time,
         end_datetime=flight_time,
-        originating_party="Test Organizer",
+        originating_party="Party 001",
         flight_declaration_raw_geojson=json.dumps(
             {
                 "type": "FeatureCollection",
@@ -90,3 +90,164 @@ def create_flight_plan(db) -> fdo_models.FlightDeclaration:
             }
         ),
     )
+    # Flight plan 2
+
+    max_alt = 120
+    min_alt = 70
+    fdo_models.FlightDeclaration.objects.create(
+        operational_intent={
+            "volumes": [
+                {
+                    "volume": {
+                        "outline_polygon": {
+                            "vertices": [
+                                {
+                                    "lat": 3.0000070710678117,
+                                    "lng": 1.999992928932188,
+                                },
+                                {
+                                    "lat": 3.000007730104534,
+                                    "lng": 1.9999936560671583,
+                                },
+                                {
+                                    "lat": 2.0000070710678117,
+                                    "lng": 0.9999929289321882,
+                                },
+                            ]
+                        },
+                        "altitude_lower": {
+                            "value": min_alt,
+                            "reference": "W84",
+                            "units": "M",
+                        },
+                        "altitude_upper": {
+                            "value": max_alt,
+                            "reference": "W84",
+                            "units": "M",
+                        },
+                        "outline_circle": None,
+                    },
+                    "time_start": {
+                        "format": "RFC3339",
+                        "value": "2023-07-26T15:00:00+00:00",
+                    },
+                    "time_end": {
+                        "format": "RFC3339",
+                        "value": "2023-07-26T16:00:00+00:00",
+                    },
+                }
+            ],
+            "priority": 0,
+            "state": "Accepted",
+            "off_nominal_volumes": [],
+        },
+        bounds="",
+        type_of_operation=1,
+        submitted_by="User 002",
+        is_approved=False,
+        start_datetime=flight_time,
+        end_datetime=flight_time,
+        originating_party="PArty 002",
+        flight_declaration_raw_geojson=json.dumps(
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "properties": {
+                            "id": "0",
+                            "start_datetime": "2023-08-10T16:29:08.842Z",
+                            "end_datetime": "2023-08-10T19:29:08.842Z",
+                            "max_altitude": {"meters": max_alt, "datum": "agl"},
+                            "min_altitude": {"meters": min_alt, "datum": "agl"},
+                        },
+                        "geometry": {
+                            "coordinates": [[1, 2], [2, 3]],
+                            "type": "LineString",
+                        },
+                    }
+                ],
+            }
+        ),
+    )
+    # Flight plan 2
+    max_alt = 100
+    min_alt = 80
+    fdo_models.FlightDeclaration.objects.create(
+        operational_intent={
+            "volumes": [
+                {
+                    "volume": {
+                        "outline_polygon": {
+                            "vertices": [
+                                {
+                                    "lat": 3.0000070710678117,
+                                    "lng": 1.999992928932188,
+                                },
+                                {
+                                    "lat": 3.000007730104534,
+                                    "lng": 1.9999936560671583,
+                                },
+                                {
+                                    "lat": 2.0000070710678117,
+                                    "lng": 0.9999929289321882,
+                                },
+                            ]
+                        },
+                        "altitude_lower": {
+                            "value": min_alt,
+                            "reference": "W84",
+                            "units": "M",
+                        },
+                        "altitude_upper": {
+                            "value": max_alt,
+                            "reference": "W84",
+                            "units": "M",
+                        },
+                        "outline_circle": None,
+                    },
+                    "time_start": {
+                        "format": "RFC3339",
+                        "value": "2023-07-26T15:00:00+00:00",
+                    },
+                    "time_end": {
+                        "format": "RFC3339",
+                        "value": "2023-07-26T16:00:00+00:00",
+                    },
+                }
+            ],
+            "priority": 0,
+            "state": "Accepted",
+            "off_nominal_volumes": [],
+        },
+        bounds="",
+        type_of_operation=1,
+        submitted_by="User 003",
+        is_approved=False,
+        start_datetime=flight_time,
+        end_datetime=flight_time,
+        originating_party="Party 003",
+        flight_declaration_raw_geojson=json.dumps(
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "properties": {
+                            "id": "0",
+                            "start_datetime": "2023-08-10T16:29:08.842Z",
+                            "end_datetime": "2023-08-10T19:29:08.842Z",
+                            "max_altitude": {"meters": max_alt, "datum": "agl"},
+                            "min_altitude": {"meters": min_alt, "datum": "agl"},
+                        },
+                        "geometry": {
+                            "coordinates": [[1, 2], [2, 3]],
+                            "type": "LineString",
+                        },
+                    }
+                ],
+            }
+        ),
+    )
+    yield
+    fdo_models.FlightDeclaration.objects.all().delete()

--- a/flight_declaration_operations/migrations/0001_initial.py
+++ b/flight_declaration_operations/migrations/0001_initial.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             name='FlightDeclaration',
             fields=[
                 ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
-                ('operational_intent', models.TextField()),
+                ('operational_intent', models.JSONField()),
                 ('flight_declaration_raw_geojson', models.TextField(blank=True, null=True)),
                 ('type_of_operation', models.IntegerField(choices=[(0, 'VLOS'), (1, 'BVLOS')], default=0, help_text='At the moment, only VLOS and BVLOS operations are supported, for other types of operations, please issue a pull-request')),
                 ('bounds', models.CharField(max_length=140)),

--- a/flight_declaration_operations/models.py
+++ b/flight_declaration_operations/models.py
@@ -9,7 +9,7 @@ class FlightDeclaration(models.Model):
     OPERATION_STATE = ((0, _('Not Submitted')),(1, _('Accepted')),(2, _('Activated')),(3,_('Nonconforming')),(4,_('Contingent')),(5,_('Ended')),)    
     
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    operational_intent = models.TextField()
+    operational_intent = models.JSONField()
     flight_declaration_raw_geojson = models.TextField(null=True, blank=True)
     type_of_operation = models.IntegerField(choices=OPERATION_TYPES, default=1, help_text="At the moment, only VLOS and BVLOS operations are supported, for other types of operations, please issue a pull-request")
     state = models.IntegerField(choices=OPERATION_STATE, default=0, help_text="Set the state of operation")

--- a/flight_declaration_operations/serializers.py
+++ b/flight_declaration_operations/serializers.py
@@ -2,7 +2,9 @@
 This module holds the Serialization classes to be used in Flight Declaration operations.
 """
 import json
+
 from rest_framework import serializers
+
 from .models import FlightDeclaration
 from .utils import OperationalIntentsConverter
 

--- a/flight_declaration_operations/serializers.py
+++ b/flight_declaration_operations/serializers.py
@@ -61,7 +61,7 @@ class FlightDeclarationSerializer(serializers.ModelSerializer):
     flight_declaration_raw_geojson = serializers.SerializerMethodField()
 
     def get_flight_declaration_geojson(self, obj):
-        o = json.loads(obj.operational_intent)
+        o = obj.operational_intent
 
         my_operational_intent_converter = OperationalIntentsConverter()
         my_operational_intent_converter.convert_operational_intent_to_geo_json(
@@ -74,7 +74,7 @@ class FlightDeclarationSerializer(serializers.ModelSerializer):
         return json.loads(obj.flight_declaration_raw_geojson)
 
     def get_operational_intent(self, obj):
-        return json.loads(obj.operational_intent)
+        return obj.operational_intent
 
     class Meta:
         model = FlightDeclaration

--- a/flight_declaration_operations/test_views.py
+++ b/flight_declaration_operations/test_views.py
@@ -4,6 +4,7 @@ This file contains unit tests for the views functions in flight_declaration_oper
 import json
 import datetime
 from django.urls import reverse
+import pytest
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -200,3 +201,17 @@ class FlightDeclarationPostTests(APITestCase):
         )
         self.assertEqual(response.json()["message"], "Submitted Flight Declaration")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+@pytest.mark.usefixtures("create_flight_plan")
+class FlightDeclarationGetTests(APITestCase):
+    def setUp(self):
+        self.client.defaults["HTTP_AUTHORIZATION"] = "Bearer " + JWT
+        self.api_url = reverse("flight_declaration")
+
+    def test_count_flight_plans(self):
+        response = self.client.get(
+            self.api_url,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["total"], 5)

--- a/flight_declaration_operations/test_views.py
+++ b/flight_declaration_operations/test_views.py
@@ -202,16 +202,53 @@ class FlightDeclarationPostTests(APITestCase):
         self.assertEqual(response.json()["message"], "Submitted Flight Declaration")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+
 @pytest.mark.usefixtures("create_flight_plan")
 class FlightDeclarationGetTests(APITestCase):
     def setUp(self):
         self.client.defaults["HTTP_AUTHORIZATION"] = "Bearer " + JWT
         self.api_url = reverse("flight_declaration")
 
-    def test_count_flight_plans(self):
+    def test_count_flight_plans_with_default_filter(self):
         response = self.client.get(
             self.api_url,
             content_type="application/json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["total"], 5)
+        self.assertEqual(response.json()["total"], 3)
+
+    def test_count_flight_plans_with_altitude_filter_1(self):
+        response = self.client.get(
+            self.api_url + "?min_alt=90",
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["total"], 1)
+
+    def test_count_flight_plans_with_altitude_filter_2(self):
+        response = self.client.get(
+            self.api_url + "?max_alt=100",
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["total"], 2)
+
+    def test_count_flight_plans_with_altitude_filter_3(self):
+        response = self.client.get(
+            self.api_url + "?max_alt=100&min_alt=90",
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["total"], 1)
+
+    def test_count_flight_plans_with_datetime_filter_1(self):
+        flight_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        response = self.client.get(
+            self.api_url
+            + "?start_date={flight_time}&end_date={flight_time}".format(
+                flight_time=flight_time
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["total"], 3)

--- a/flight_declaration_operations/urls.py
+++ b/flight_declaration_operations/urls.py
@@ -24,7 +24,7 @@ urlpatterns = [
         name="set_flight_declaration",
     ),
     path(
-        "flight_declaration", flight_declaration_views.FlightDeclarationList.as_view()
+        "flight_declaration", flight_declaration_views.FlightDeclarationList.as_view(),name="flight_declaration"
     ),
     path(
         "flight_declaration/<uuid:pk>",

--- a/flight_declaration_operations/utils.py
+++ b/flight_declaration_operations/utils.py
@@ -1,136 +1,178 @@
-from scd_operations.scd_data_definitions import Altitude, Volume3D, Volume4D, LatLngPoint, Time, OperationalIntentUSSDetails, PartialCreateOperationalIntentReference
-from scd_operations.scd_data_definitions import Polygon as Plgn
-import shapely.geometry
-from shapely.geometry import shape, Point, Polygon
-from pyproj import Proj
-from typing import List
-from geojson import FeatureCollection
-from shapely.ops import unary_union
-
 from os import environ as env
-from dotenv import load_dotenv, find_dotenv
+from typing import List
+
+import shapely.geometry
+from dotenv import find_dotenv, load_dotenv
+from geojson import FeatureCollection
+from pyproj import Proj
+from scd_operations.scd_data_definitions import (
+    Altitude, LatLngPoint, OperationalIntentUSSDetails,
+    PartialCreateOperationalIntentReference)
+from scd_operations.scd_data_definitions import Polygon as Plgn
+from scd_operations.scd_data_definitions import Time, Volume3D, Volume4D
+from shapely.geometry import Point, Polygon, shape
+from shapely.ops import unary_union
 
 ENV_FILE = find_dotenv()
 if ENV_FILE:
     load_dotenv(ENV_FILE)
 
-class OperationalIntentsConverter():
-    ''' A class to covert a operational Intnet  in to GeoJSON '''
+
+class OperationalIntentsConverter:
+    """A class to covert a operational Intnet  in to GeoJSON"""
+
     def __init__(self):
-        self.geo_json = {"type":"FeatureCollection","features":[]}
-        self.utm_zone = '54N' # Zone for Switzerland
+        self.geo_json = {"type": "FeatureCollection", "features": []}
+        self.utm_zone = "54N"  # Zone for Switzerland
         self.all_features = []
-        
-    def utm_converter(self, shapely_shape: shapely.geometry, inverse:bool=False) -> shapely.geometry.shape:
-        ''' A helper function to convert from lat / lon to UTM coordinates for buffering. tracks. This is the UTM projection (https://en.wikipedia.org/wiki/Universal_Transverse_Mercator_coordinate_system), we use Zone 54N which encompasses Japan, this zone has to be set for each locale / city. Adapted from https://gis.stackexchange.com/questions/325926/buffering-geometry-with-points-in-wgs84-using-shapely '''
+
+    def utm_converter(
+        self, shapely_shape: shapely.geometry, inverse: bool = False
+    ) -> shapely.geometry.shape:
+        """A helper function to convert from lat / lon to UTM coordinates for buffering. tracks. This is the UTM projection (https://en.wikipedia.org/wiki/Universal_Transverse_Mercator_coordinate_system), we use Zone 54N which encompasses Japan, this zone has to be set for each locale / city. Adapted from https://gis.stackexchange.com/questions/325926/buffering-geometry-with-points-in-wgs84-using-shapely"""
 
         proj = Proj(proj="utm", zone=self.utm_zone, ellps="WGS84", datum="WGS84")
 
         geo_interface = shapely_shape.__geo_interface__
-        point_or_polygon = geo_interface['type']
-        coordinates = geo_interface['coordinates']
-        if point_or_polygon == 'Polygon':
-            new_coordinates = [[proj(*point, inverse=inverse) for point in linring] for linring in coordinates]
-        elif point_or_polygon == 'Point':
+        point_or_polygon = geo_interface["type"]
+        coordinates = geo_interface["coordinates"]
+        if point_or_polygon == "Polygon":
+            new_coordinates = [
+                [proj(*point, inverse=inverse) for point in linring]
+                for linring in coordinates
+            ]
+        elif point_or_polygon == "Point":
             new_coordinates = proj(*coordinates, inverse=inverse)
         else:
-            raise RuntimeError('Unexpected geo_interface type: {}'.format(point_or_polygon))
+            raise RuntimeError(
+                "Unexpected geo_interface type: {}".format(point_or_polygon)
+            )
 
-        return shapely.geometry.shape({'type': point_or_polygon, 'coordinates': tuple(new_coordinates)})
+        return shapely.geometry.shape(
+            {"type": point_or_polygon, "coordinates": tuple(new_coordinates)}
+        )
 
-    def convert_operational_intent_to_geo_json(self,volumes: List[Volume4D]):
+    def convert_operational_intent_to_geo_json(self, volumes: List[Volume4D]):
         for volume in volumes:
-            geo_json_features = self._convert_operational_intent_to_geojson_feature(volume)
-            self.geo_json['features'] += geo_json_features
+            geo_json_features = self._convert_operational_intent_to_geojson_feature(
+                volume
+            )
+            self.geo_json["features"] += geo_json_features
 
+    def create_partial_operational_intent_ref(
+        self,
+        start_datetime: str,
+        end_datetime: str,
+        geo_json_fc: FeatureCollection,
+        priority: int,
+        state: str = "Accepted",
+    ) -> PartialCreateOperationalIntentReference:
+        all_v4d = self.convert_geo_json_to_volume4D(
+            geo_json_fc=geo_json_fc,
+            start_datetime=start_datetime,
+            end_datetime=end_datetime,
+        )
 
-    def create_partial_operational_intent_ref(self, start_datetime: str, end_datetime:str, geo_json_fc: FeatureCollection, priority:int ,state:str ="Accepted") -> PartialCreateOperationalIntentReference:        
-        all_v4d = self.convert_geo_json_to_volume4D(geo_json_fc = geo_json_fc, start_datetime = start_datetime, end_datetime = end_datetime)
-
-        op_int_r = PartialCreateOperationalIntentReference(volumes = all_v4d,  state = state,priority =priority, off_nominal_volumes= [] )       
-
+        op_int_r = PartialCreateOperationalIntentReference(
+            volumes=all_v4d, state=state, priority=priority, off_nominal_volumes=[]
+        )
 
         return op_int_r
 
-    def convert_geo_json_to_volume4D(self, geo_json_fc: FeatureCollection, start_datetime: str, end_datetime:str) -> List[Volume4D]:
+    def convert_geo_json_to_volume4D(
+        self, geo_json_fc: FeatureCollection, start_datetime: str, end_datetime: str
+    ) -> List[Volume4D]:
         all_v4d = []
         # all_shapes = []
-        all_features = geo_json_fc['features']
+        all_features = geo_json_fc["features"]
         for feature in all_features:
-            geom = feature['geometry']
-            max_altitude = feature['properties']['max_altitude']['meters']
-            min_altitude = feature['properties']['min_altitude']['meters']
-            s = shape(geom)     
+            geom = feature["geometry"]
+            max_altitude = feature["properties"]["max_altitude"]["meters"]
+            min_altitude = feature["properties"]["min_altitude"]["meters"]
+            s = shape(geom)
             buffed_s = s.buffer(0.00001)
             # all_shapes.append(buffed_s)
-            self.all_features.append(buffed_s)  
+            self.all_features.append(buffed_s)
             # feature_union = unary_union(all_shapes)
-            # # TODO: build a better flightplan 
+            # # TODO: build a better flightplan
             # b = feature_union.minimum_rotated_rectangle
-            
+
             co_ordinates = list(zip(*buffed_s.exterior.coords.xy))
             # Convert bounds vertex list
             polygon_verticies = []
             for cur_co_ordinate in co_ordinates:
-                v = LatLngPoint(lat = cur_co_ordinate[1],lng = cur_co_ordinate[0])
+                v = LatLngPoint(lat=cur_co_ordinate[1], lng=cur_co_ordinate[0])
                 polygon_verticies.append(v)
 
             # remove the final point
             polygon_verticies.pop()
-                
-            volume3D = Volume3D(outline_polygon=Plgn(vertices= polygon_verticies),altitude_lower=Altitude(value=max_altitude,reference='W84',units='M'), altitude_upper=Altitude(value=min_altitude,reference='W84',units='M'))
 
-            volume4D = Volume4D(volume = volume3D, time_start=Time(format="RFC3339",value=start_datetime), time_end=Time(format="RFC3339", value=end_datetime))
+            volume3D = Volume3D(
+                outline_polygon=Plgn(vertices=polygon_verticies),
+                altitude_lower=Altitude(value=min_altitude, reference="W84", units="M"),
+                altitude_upper=Altitude(value=max_altitude, reference="W84", units="M"),
+            )
+
+            volume4D = Volume4D(
+                volume=volume3D,
+                time_start=Time(format="RFC3339", value=start_datetime),
+                time_end=Time(format="RFC3339", value=end_datetime),
+            )
             all_v4d.append(volume4D)
-        
-        
 
         return all_v4d
-    
 
     def get_geo_json_bounds(self) -> str:
-            
-        combined_features = unary_union(self.all_features)        
-        bnd_tuple = combined_features.bounds        
-        bounds = ','.join(['{:.7f}'.format(x) for x in bnd_tuple])
+        combined_features = unary_union(self.all_features)
+        bnd_tuple = combined_features.bounds
+        bounds = ",".join(["{:.7f}".format(x) for x in bnd_tuple])
 
-        return bounds    
+        return bounds
 
     def _convert_operational_intent_to_geojson_feature(self, volume: Volume4D):
-        
         geo_json_features = []
-        v = volume['volume']
-        time_start = volume['time_start']
-        time_end = volume['time_end']
-        if ('outline_polygon'in v and v['outline_polygon'] is not None):
-            outline_polygon = v['outline_polygon']
+        v = volume["volume"]
+        time_start = volume["time_start"]
+        time_end = volume["time_end"]
+        if "outline_polygon" in v and v["outline_polygon"] is not None:
+            outline_polygon = v["outline_polygon"]
             point_list = []
-            
-            for vertex in outline_polygon['vertices']:
-                p = Point(vertex['lng'], vertex['lat'])
+
+            for vertex in outline_polygon["vertices"]:
+                p = Point(vertex["lng"], vertex["lat"])
                 point_list.append(p)
             outline_polygon = Polygon([[p.x, p.y] for p in point_list])
             self.all_features.append(outline_polygon)
-            
+
             oriented = shapely.geometry.polygon.orient(outline_polygon)
             outline_p = shapely.geometry.mapping(oriented)
-            
-            polygon_feature = {'type': 'Feature', 'properties': {'time_start':time_start, 'time_end':time_end}, 'geometry': outline_p}
+
+            polygon_feature = {
+                "type": "Feature",
+                "properties": {"time_start": time_start, "time_end": time_end},
+                "geometry": outline_p,
+            }
             geo_json_features.append(polygon_feature)
 
-        if ('outline_circle' in v and v['outline_circle'] is not None):
-            outline_circle = v['outline_circle']
-            circle_radius = outline_circle['radius']['value']
-            center_point = Point(outline_circle['center']['lng'],outline_circle['center']['lat'])
-            utm_center = self.utm_converter(shapely_shape = center_point)
+        if "outline_circle" in v and v["outline_circle"] is not None:
+            outline_circle = v["outline_circle"]
+            circle_radius = outline_circle["radius"]["value"]
+            center_point = Point(
+                outline_circle["center"]["lng"], outline_circle["center"]["lat"]
+            )
+            utm_center = self.utm_converter(shapely_shape=center_point)
             buffered_cicle = utm_center.buffer(circle_radius)
             converted_circle = self.utm_converter(buffered_cicle, inverse=True)
             self.all_features.append(converted_circle)
-            
+
             outline_c = shapely.geometry.mapping(converted_circle)
 
-            circle_feature = {'type': 'Feature','properties': {'time_start':time_start, 'time_end':time_end}, 'geometry': outline_c}
-            
+            circle_feature = {
+                "type": "Feature",
+                "properties": {"time_start": time_start, "time_end": time_end},
+                "geometry": outline_c,
+            }
+
             geo_json_features.append(circle_feature)
-        
+
         return geo_json_features

--- a/flight_declaration_operations/views.py
+++ b/flight_declaration_operations/views.py
@@ -208,7 +208,7 @@ def set_flight_declaration(request: HttpRequest):
             is_approved = 0
 
     fo = FlightDeclaration(
-        operational_intent=json.dumps(asdict(partial_op_int_ref)),
+        operational_intent=json.loads(json.dumps(asdict(partial_op_int_ref))),
         bounds=bounds,
         type_of_operation=flight_declaration_request.type_of_operation,
         submitted_by=flight_declaration_request.submitted_by,
@@ -338,6 +338,9 @@ class FlightDeclarationList(mixins.ListModelMixin, generics.GenericAPIView):
         else:
             filtered_relevant_fd = all_fd_within_timelimits
 
+        
+        test_records = FlightDeclaration.objects.filter(operational_intent_test__volumes__0__volume__altitude_upper__value=10)
+        print(test_records)
         return filtered_relevant_fd
 
     def get_queryset(self):

--- a/flight_declaration_operations/views.py
+++ b/flight_declaration_operations/views.py
@@ -302,14 +302,15 @@ class FlightDeclarationList(mixins.ListModelMixin, generics.GenericAPIView):
     def get_relevant_flight_declaration(
         self, start_date, end_date, view_port: List[float]
     ):
-        present = arrow.now()
         if start_date and end_date:
-            s_date = arrow.get(start_date, "YYYY-MM-DD")
-            e_date = arrow.get(end_date, "YYYY-MM-DD")
+            s_date = arrow.get(start_date, "YYYY-MM-DD HH:mm:ss")
+            e_date = arrow.get(end_date, "YYYY-MM-DD HH:mm:ss")
 
         else:
+            present = arrow.now()
             s_date = present.shift(days=-1)
             e_date = present.shift(days=1)
+
         all_fd_within_timelimits = FlightDeclaration.objects.filter(
             start_datetime__gte=s_date.isoformat(), end_datetime__lte=e_date.isoformat()
         )

--- a/flight_declaration_operations/views.py
+++ b/flight_declaration_operations/views.py
@@ -1,5 +1,6 @@
 # Create your views here.
 import io
+
 # Create your views here.
 import json
 import logging
@@ -21,16 +22,16 @@ from rest_framework.renderers import JSONRenderer
 from shapely.geometry import shape
 
 from .data_definitions import FlightDeclarationCreateResponse
-from .flight_declarations_rtree_helper import \
-    FlightDeclarationRTreeIndexFactory
+from .flight_declarations_rtree_helper import FlightDeclarationRTreeIndexFactory
 from .models import FlightDeclaration
 from .pagination import StandardResultsSetPagination
-from .serializers import (FlightDeclarationApprovalSerializer,
-                          FlightDeclarationRequestSerializer,
-                          FlightDeclarationSerializer,
-                          FlightDeclarationStateSerializer)
-from .tasks import (send_operational_update_message,
-                    submit_flight_declaration_to_dss)
+from .serializers import (
+    FlightDeclarationApprovalSerializer,
+    FlightDeclarationRequestSerializer,
+    FlightDeclarationSerializer,
+    FlightDeclarationStateSerializer,
+)
+from .tasks import send_operational_update_message, submit_flight_declaration_to_dss
 from .utils import OperationalIntentsConverter
 
 logger = logging.getLogger("django")
@@ -238,7 +239,7 @@ def set_flight_declaration(request: HttpRequest):
             "Self deconfliction failed, this declaration cannot be sent to the DSS system.."
         )
         if amqp_connection_url:
-            self_deconfliction_failed_msg = "Self deconfliction failed for operation {operation_id} did not pass self-deconfliction, there are existing operationd declared".format(
+            self_deconfliction_failed_msg = "Self deconfliction failed for operation {operation_id} did not pass self-deconfliction, there are existing operations declared".format(
                 operation_id=flight_declaration_id
             )
             send_operational_update_message.delay(


### PR DESCRIPTION
## Proposed changes

[JIRA](https://ssrc.atlassian.net/browse/SCUTM-178)

- FlightPlan query API endpoint `GET /flight_declaration_ops/flight_declaration`  doesn’t obey the **timestamp** values in the API query for start_date and end_date
- Also When creating a FlightPlan, altitude values were interchanged.

Changes:

- Improved the current `start_date` & `end_date` filter to consider time value. Flight plans now can be filtered with date and time.
- Introduced Altitude query parameters: `min_alt, max_alt` to filter flight plans from min and max altitudes.
      - Converted `operational_intent` database column from **Text** type column to **JSON** column in order to implement the altitude filter.
      - Fixed altitude values saving problem



## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with the changes
- [ ] Added new tests that prove the changes in this PR works
- [ ] Added necessary documentation (if appropriate)
- [ ] Added copyrights to new files (if appropriate)

## Further comments

To run the modified endpoint:

- Datetime filter: `/flight_declaration_ops/flight_declaration?start_date=2023-07-26 15:00:00&end_date=2023-07-31 16:30:45`
- Altitude filter:` /flight_declaration_ops/flight_declaration?min_alt=100&max_alt=500`
- All filters:` /flight_declaration_ops/flight_declaration?start_date=2023-07-26 15:00:00&end_date=2023-07-31 16:30:45&min_alt=100&max_alt=500`