### PR TITLE
Prepping flight_plan module to have non-repudiation

### DIFF
--- a/flight_declaration_operations/serializers.py
+++ b/flight_declaration_operations/serializers.py
@@ -39,8 +39,8 @@ class FlightDeclarationRequestSerializer(serializers.Serializer):
     originating_party = serializers.CharField(
         required=False, default="No Flight Information"
     )
-    start_datetime = serializers.DateTimeField()
-    end_datetime = serializers.DateTimeField()
+    start_datetime = serializers.DateTimeField(required=False, default=None)
+    end_datetime = serializers.DateTimeField(required=False,default=None)
     type_of_operation = serializers.IntegerField(required=False, default=0)
     submitted_by = serializers.CharField(required=False, default=None)
     flight_declaration_geo_json = serializers.DictField(

--- a/flight_declaration_operations/test_views.py
+++ b/flight_declaration_operations/test_views.py
@@ -66,8 +66,6 @@ class FlightDeclarationPostTests(APITestCase):
             self.api_url, content_type="application/json", data=empty_payload
         )
         response_json = {
-            "start_datetime": ["This field is required."],
-            "end_datetime": ["This field is required."],
             "flight_declaration_geo_json": [
                 "A valid flight declaration as specified by the A flight declaration protocol must be submitted."
             ],
@@ -209,6 +207,7 @@ class FlightDeclarationGetTests(APITestCase):
     """
     Contains tests for class FlightDeclarationList
     """
+
     def setUp(self):
         self.client.defaults["HTTP_AUTHORIZATION"] = "Bearer " + JWT
         self.api_url = reverse("flight_declaration")
@@ -219,39 +218,57 @@ class FlightDeclarationGetTests(APITestCase):
             content_type="application/json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["total"], 3)
+        self.assertEqual(response.json()["total"], 0)
 
     def test_count_flight_plans_with_altitude_filter_1(self):
+        flight_s_time = "2023-08-01 00:00:00"
+        flight_e_time = "2023-08-01 23:00:00"
         response = self.client.get(
-            self.api_url + "?min_alt=90",
+            self.api_url
+            + "?min_alt=90"
+            + "&start_date={flight_s_time}&end_date={flight_e_time}".format(
+                flight_s_time=flight_s_time, flight_e_time=flight_e_time
+            ),
             content_type="application/json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["total"], 1)
 
     def test_count_flight_plans_with_altitude_filter_2(self):
+        flight_s_time = "2023-08-01 00:00:00"
+        flight_e_time = "2023-08-01 23:00:00"
         response = self.client.get(
-            self.api_url + "?max_alt=100",
+            self.api_url
+            + "?max_alt=100"
+            + "&start_date={flight_s_time}&end_date={flight_e_time}".format(
+                flight_s_time=flight_s_time, flight_e_time=flight_e_time
+            ),
             content_type="application/json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["total"], 2)
 
     def test_count_flight_plans_with_altitude_filter_3(self):
+        flight_s_time = "2023-08-01 00:00:00"
+        flight_e_time = "2023-08-01 23:00:00"
         response = self.client.get(
-            self.api_url + "?max_alt=100&min_alt=90",
+            self.api_url
+            + "?max_alt=100&min_alt=90"
+            + "&start_date={flight_s_time}&end_date={flight_e_time}".format(
+                flight_s_time=flight_s_time, flight_e_time=flight_e_time
+            ),
             content_type="application/json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["total"], 1)
 
     def test_count_flight_plans_with_datetime_filter_1(self):
-        flight_s_time ="2023-08-01 06:00:00"
-        flight_e_time="2023-08-01 23:00:00"
+        flight_s_time = "2023-08-01 06:00:00"
+        flight_e_time = "2023-08-01 23:00:00"
         response = self.client.get(
             self.api_url
             + "?start_date={flight_s_time}&end_date={flight_e_time}".format(
-                flight_s_time=flight_s_time,flight_e_time=flight_e_time
+                flight_s_time=flight_s_time, flight_e_time=flight_e_time
             ),
             content_type="application/json",
         )

--- a/flight_declaration_operations/test_views.py
+++ b/flight_declaration_operations/test_views.py
@@ -1,10 +1,11 @@
 """
 This file contains unit tests for the views functions in flight_declaration_operations
 """
-import json
 import datetime
-from django.urls import reverse
+import json
+
 import pytest
+from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 

--- a/flight_declaration_operations/urls.py
+++ b/flight_declaration_operations/urls.py
@@ -23,6 +23,11 @@ urlpatterns = [
         flight_declaration_views.set_flight_declaration,
         name="set_flight_declaration",
     ),
+        path(
+        "set_signed_flight_declaration",
+        flight_declaration_views.set_signed_flight_declaration,
+        name="set_signed_flight_declaration",
+    ),
     path(
         "flight_declaration", flight_declaration_views.FlightDeclarationList.as_view(),name="flight_declaration"
     ),

--- a/flight_declaration_operations/urls.py
+++ b/flight_declaration_operations/urls.py
@@ -15,6 +15,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+
 from . import views as flight_declaration_views
 
 urlpatterns = [

--- a/flight_declaration_operations/views.py
+++ b/flight_declaration_operations/views.py
@@ -1,11 +1,9 @@
 # Create your views here.
 import io
-
 # Create your views here.
 import json
 import logging
 from dataclasses import asdict
-from os import environ as env
 from typing import List
 
 import arrow
@@ -15,25 +13,23 @@ from django.utils.decorators import method_decorator
 from rest_framework import generics, mixins, status
 from rest_framework.decorators import api_view
 from rest_framework.parsers import JSONParser
-from rest_framework.renderers import JSONRenderer
 from shapely.geometry import shape
 
 from auth_helper.utils import requires_scopes
-from flight_feed_operations import data_definitions, pki_helper
 from geo_fence_operations import rtree_geo_fence_helper
 from geo_fence_operations.models import GeoFence
 
 from .data_definitions import FlightDeclarationCreateResponse
-from .flight_declarations_rtree_helper import FlightDeclarationRTreeIndexFactory
+from .flight_declarations_rtree_helper import \
+    FlightDeclarationRTreeIndexFactory
 from .models import FlightDeclaration
 from .pagination import StandardResultsSetPagination
-from .serializers import (
-    FlightDeclarationApprovalSerializer,
-    FlightDeclarationRequestSerializer,
-    FlightDeclarationSerializer,
-    FlightDeclarationStateSerializer,
-)
-from .tasks import send_operational_update_message, submit_flight_declaration_to_dss
+from .serializers import (FlightDeclarationApprovalSerializer,
+                          FlightDeclarationRequestSerializer,
+                          FlightDeclarationSerializer,
+                          FlightDeclarationStateSerializer)
+from .tasks import (send_operational_update_message,
+                    submit_flight_declaration_to_dss)
 from .utils import OperationalIntentsConverter
 
 logger = logging.getLogger("django")

--- a/flight_declaration_operations/views.py
+++ b/flight_declaration_operations/views.py
@@ -9,17 +9,19 @@ from os import environ as env
 from typing import List
 
 import arrow
-from auth_helper.utils import requires_scopes
 from django.db.models import Q
 from django.http import HttpRequest, HttpResponse
 from django.utils.decorators import method_decorator
-from geo_fence_operations import rtree_geo_fence_helper
-from geo_fence_operations.models import GeoFence
 from rest_framework import generics, mixins, status
 from rest_framework.decorators import api_view
 from rest_framework.parsers import JSONParser
 from rest_framework.renderers import JSONRenderer
 from shapely.geometry import shape
+
+from auth_helper.utils import requires_scopes
+from flight_feed_operations import data_definitions, pki_helper
+from geo_fence_operations import rtree_geo_fence_helper
+from geo_fence_operations.models import GeoFence
 
 from .data_definitions import FlightDeclarationCreateResponse
 from .flight_declarations_rtree_helper import FlightDeclarationRTreeIndexFactory
@@ -33,133 +35,104 @@ from .serializers import (
 )
 from .tasks import send_operational_update_message, submit_flight_declaration_to_dss
 from .utils import OperationalIntentsConverter
-from flight_feed_operations import pki_helper,data_definitions
+
 logger = logging.getLogger("django")
 
 
-@api_view(["POST"])
-@requires_scopes(["blender.write"])
-def set_flight_declaration(request: HttpRequest):
+def _parse_flight_declaration_request(json_payload):
     """
-    Add a new Flight Declaration. Submit a Flight Declaration into Flight Blender.
+    Validate the JSON payload to make sure all required fields are provided and the flight times are in proper order
     """
-    try:
-        assert request.headers["Content-Type"] == "application/json"
-    except AssertionError:
-        msg = {"message": "Unsupported Media Type"}
-        return HttpResponse(
-            json.dumps(msg),
-            status=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-            content_type="application/json",
-        )
-
-    stream = io.BytesIO(request.body)
-    json_payload = JSONParser().parse(stream)
-
+    error = None
+    fd_request = None
     serializer = FlightDeclarationRequestSerializer(data=json_payload)
     if not serializer.is_valid():
-        return HttpResponse(
-            JSONRenderer().render(serializer.errors),
-            status=status.HTTP_400_BAD_REQUEST,
-            content_type="application/json",
-        )
+        error = serializer.errors
+        return fd_request, error
 
-    flight_declaration_request = serializer.create(serializer.validated_data)
-    is_approved = False
+    fd_request = serializer.create(serializer.validated_data)
 
+    # Validate flight time fields
     now = arrow.now()
     try:
-        start_datetime = (
+        fd_request.start_datetime = (
             now.isoformat()
-            if "start_datetime" not in json_payload
-            else arrow.get(json_payload["start_datetime"]).isoformat()
+            if fd_request.start_datetime is None
+            else arrow.get(fd_request.start_datetime).isoformat()
         )
-        end_datetime = (
+        fd_request.end_datetime = (
             now.isoformat()
-            if "end_datetime" not in json_payload
-            else arrow.get(json_payload["end_datetime"]).isoformat()
+            if fd_request.end_datetime is None
+            else arrow.get(fd_request.end_datetime).isoformat()
         )
     except Exception:
         ten_mins_from_now = now.shift(minutes=10)
-        start_datetime = now.isoformat()
-        end_datetime = ten_mins_from_now.isoformat()
+        fd_request.start_datetime = now.isoformat()
+        fd_request.end_datetime = ten_mins_from_now.isoformat()
 
     two_days_from_now = now.shift(days=2)
 
     # verify start and end date time
-    s_datetime = arrow.get(start_datetime)
-    e_datetime = arrow.get(end_datetime)
-
+    s_datetime = arrow.get(fd_request.start_datetime)
+    e_datetime = arrow.get(fd_request.end_datetime)
     if (
         s_datetime < now
         or e_datetime < now
         or e_datetime > two_days_from_now
         or s_datetime > two_days_from_now
     ):
-        return HttpResponse(
-            json.dumps(
-                {
-                    "message": "A flight declaration cannot have a start or end time in the past or after two days from current time."
-                }
-            ),
-            status=status.HTTP_400_BAD_REQUEST,
-            content_type="application/json",
-        )
-    all_features = []
+        error = {
+            "message": "A flight declaration cannot have a start or end time in the past or after two days from current time."
+        }
 
-    for feature in flight_declaration_request.flight_declaration_geo_json["features"]:
+    # Validate GeoJSON
+    all_features = []  # TODO Do we need this all_features?
+    for feature in fd_request.flight_declaration_geo_json["features"]:
         geometry = feature["geometry"]
         s = shape(geometry)
         if s.is_valid:
             all_features.append(s)
         else:
-            op = json.dumps(
-                {
-                    "message": "Error in processing the submitted GeoJSON: every Feature in a GeoJSON FeatureCollection must have a valid geometry, please check your submitted FeatureCollection"
-                }
-            )
-            return HttpResponse(
-                op, status=status.HTTP_400_BAD_REQUEST, content_type="application/json"
-            )
-
+            error = {
+                "message": "Error in processing the submitted GeoJSON: every Feature in a GeoJSON FeatureCollection must have a valid geometry, please check your submitted FeatureCollection"
+            }
         props = feature["properties"]
         try:
             assert "min_altitude" in props
             assert "max_altitude" in props
         except AssertionError:
-            op = json.dumps(
-                {
-                    "message": "Error in processing the submitted GeoJSON: every Feature in a GeoJSON FeatureCollection must have a min_altitude and max_altitude data structure"
-                }
-            )
-            return HttpResponse(
-                op, status=status.HTTP_400_BAD_REQUEST, content_type="application/json"
-            )
+            error = {
+                "message": "Error in processing the submitted GeoJSON: every Feature in a GeoJSON FeatureCollection must have a min_altitude and max_altitude data structure"
+            }
 
-    default_state = 1  # Default state is Accepted
+    return fd_request, error
 
+
+def _get_operational_intent(fd_request):
+    is_approved = False  # Default accepted is False
     my_operational_intent_converter = OperationalIntentsConverter()
-
     partial_op_int_ref = (
         my_operational_intent_converter.create_partial_operational_intent_ref(
-            geo_json_fc=flight_declaration_request.flight_declaration_geo_json,
-            start_datetime=start_datetime,
-            end_datetime=end_datetime,
+            geo_json_fc=fd_request.flight_declaration_geo_json,
+            start_datetime=fd_request.start_datetime,
+            end_datetime=fd_request.end_datetime,
             priority=0,
         )
     )
-
     bounds = my_operational_intent_converter.get_geo_json_bounds()
     logging.info("Checking intersections with Geofences..")
-    view_box = [float(i) for i in bounds.split(",")]
 
+    view_box = [float(i) for i in bounds.split(",")]
     fence_within_timelimits = GeoFence.objects.filter(
-        start_datetime__lte=start_datetime, end_datetime__gte=end_datetime
+        start_datetime__lte=fd_request.start_datetime,
+        end_datetime__gte=fd_request.end_datetime,
     ).exists()
+
     all_relevant_fences = []
     if fence_within_timelimits:
         all_fences_within_timelimits = GeoFence.objects.filter(
-            start_datetime__lte=start_datetime, end_datetime__gte=end_datetime
+            start_datetime__lte=fd_request.start_datetime,
+            end_datetime__gte=fd_request.end_datetime,
         )
         INDEX_NAME = "geofence_idx"
         my_rtree_helper = rtree_geo_fence_helper.GeoFenceRTreeIndexFactory(
@@ -183,11 +156,13 @@ def set_flight_declaration(request: HttpRequest):
 
     all_relevant_declarations = []
     existing_declaration_within_timelimits = FlightDeclaration.objects.filter(
-        start_datetime__lte=start_datetime, end_datetime__gte=end_datetime
+        start_datetime__lte=fd_request.start_datetime,
+        end_datetime__gte=fd_request.end_datetime,
     ).exists()
     if existing_declaration_within_timelimits:
         all_declarations_within_timelimits = FlightDeclaration.objects.filter(
-            start_datetime__lte=start_datetime, end_datetime__gte=end_datetime
+            start_datetime__lte=fd_request.start_datetime,
+            end_datetime__gte=fd_request.end_datetime,
         )
         INDEX_NAME = "flight_declaration_idx"
         my_fd_rtree_helper = FlightDeclarationRTreeIndexFactory(index_name=INDEX_NAME)
@@ -208,45 +183,37 @@ def set_flight_declaration(request: HttpRequest):
         if all_relevant_declarations:
             is_approved = 0
 
-    fo = FlightDeclaration(
-        operational_intent=json.loads(json.dumps(asdict(partial_op_int_ref))),
-        bounds=bounds,
-        type_of_operation=flight_declaration_request.type_of_operation,
-        submitted_by=flight_declaration_request.submitted_by,
-        is_approved=is_approved,
-        start_datetime=start_datetime,
-        end_datetime=end_datetime,
-        originating_party=flight_declaration_request.originating_party,
-        flight_declaration_raw_geojson=json.dumps(
-            flight_declaration_request.flight_declaration_geo_json
-        ),
-        state=default_state,
+    return (
+        partial_op_int_ref,
+        bounds,
+        all_relevant_fences,
+        all_relevant_declarations,
+        is_approved,
     )
-    fo.save()
 
-    flight_declaration_id = str(fo.id)
-    amqp_connection_url = env.get("AMQP_URL", 0)
-    if amqp_connection_url:
-        send_operational_update_message.delay(
-            flight_declaration_id=flight_declaration_id,
-            message_text="Flight Declaration created..",
-            level="info",
-        )
+
+def _send_fd_creation_notifications(
+    flight_declaration_id: str, all_relevant_fences, all_relevant_declarations
+) -> None:
+    send_operational_update_message.delay(
+        flight_declaration_id=flight_declaration_id,
+        message_text="Flight Declaration created..",
+        level="info",
+    )
 
     if all_relevant_fences and all_relevant_declarations:
-        # Async submic flight declaration to DSS
+        # Async submit flight declaration to DSS
         logger.info(
             "Self deconfliction failed, this declaration cannot be sent to the DSS system.."
         )
-        if amqp_connection_url:
-            self_deconfliction_failed_msg = "Self deconfliction failed for operation {operation_id} did not pass self-deconfliction, there are existing operations declared".format(
+
+        send_operational_update_message.delay(
+            flight_declaration_id=flight_declaration_id,
+            message_text="Self deconfliction failed for operation {operation_id} did not pass self-deconfliction, there are existing operations declared".format(
                 operation_id=flight_declaration_id
-            )
-            send_operational_update_message.delay(
-                flight_declaration_id=flight_declaration_id,
-                message_text=self_deconfliction_failed_msg,
-                level="error",
-            )
+            ),
+            level="error",
+        )
 
     else:
         logger.info(
@@ -255,6 +222,69 @@ def set_flight_declaration(request: HttpRequest):
         submit_flight_declaration_to_dss.delay(
             flight_declaration_id=flight_declaration_id
         )
+    return None
+
+
+@api_view(["POST"])
+@requires_scopes(["blender.write"])
+def set_flight_declaration(request: HttpRequest):
+    """
+    Add a new Flight Declaration. Submit a Flight Declaration into Flight Blender.
+    """
+    try:
+        assert request.headers["Content-Type"] == "application/json"
+    except AssertionError:
+        msg = {"message": "Unsupported Media Type"}
+        return HttpResponse(
+            json.dumps(msg),
+            status=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            content_type="application/json",
+        )
+
+    stream = io.BytesIO(request.body)
+    json_payload = JSONParser().parse(stream)
+
+    # Validate the JSON payload
+    parsed_fd_request, parse_error = _parse_flight_declaration_request(json_payload)
+
+    if parse_error:
+        return HttpResponse(
+            json.dumps(parse_error),
+            status=status.HTTP_400_BAD_REQUEST,
+            content_type="application/json",
+        )
+
+    default_state = 1  # Default state is Accepted
+    (
+        partial_op_int_ref,
+        bounds,
+        all_relevant_fences,
+        all_relevant_declarations,
+        is_approved,
+    ) = _get_operational_intent(parsed_fd_request)
+
+    fo = FlightDeclaration(
+        operational_intent=json.loads(json.dumps(asdict(partial_op_int_ref))),
+        bounds=bounds,
+        type_of_operation=parsed_fd_request.type_of_operation,
+        submitted_by=parsed_fd_request.submitted_by,
+        is_approved=is_approved,
+        start_datetime=parsed_fd_request.start_datetime,
+        end_datetime=parsed_fd_request.end_datetime,
+        originating_party=parsed_fd_request.originating_party,
+        flight_declaration_raw_geojson=json.dumps(
+            parsed_fd_request.flight_declaration_geo_json
+        ),
+        state=default_state,
+    )
+    fo.save()
+
+    # Send flight creation notifications
+    flight_declaration_id = str(fo.id)
+    _send_fd_creation_notifications(
+        flight_declaration_id, all_relevant_fences, all_relevant_declarations
+    )
+
     creation_response = FlightDeclarationCreateResponse(
         id=flight_declaration_id,
         message="Submitted Flight Declaration",
@@ -270,22 +300,12 @@ def set_flight_declaration(request: HttpRequest):
 @api_view(["POST"])
 @requires_scopes(["blender.write"])
 def set_signed_flight_declaration(request: HttpRequest):
+    return HttpResponse(
+        json.dumps({"status": "_TO_BE_IMPLEMENTED_"}),
+        status=status.HTTP_200_OK,
+        content_type="application/json",
+    )
 
-    request = request._request
-    request_verifier = pki_helper.MessageVerifier()
-    response_signer = pki_helper.ResponseSigningOperations()
-
-    request_verified = request_verifier.verify_message(request)
-    if not request_verified:
-        message = data_definitions.MessageVerificationFailedResponse(message= "Could not verify against public keys setup in Flight Blender")
-        message=asdict(message)
-        return HttpResponse(
-            json.dumps(message),
-            status=status.HTTP_400_BAD_REQUEST,
-            content_type="application/json",
-        )
-    response = set_flight_declaration(request)
-    return response
 
 @method_decorator(requires_scopes(["blender.write"]), name="dispatch")
 class FlightDeclarationApproval(mixins.UpdateModelMixin, generics.GenericAPIView):

--- a/flight_feed_operations/pki_helper.py
+++ b/flight_feed_operations/pki_helper.py
@@ -118,12 +118,10 @@ class ResponseSigningOperations:
 
         algorithms = "RS256"
         private_key = env.get("SECRET_KEY", None)
-        print(private_key)
         if private_key:
             try:
                 key = jwk.JWK.from_pem(private_key.encode("utf8"))
-            except Exception as e:
-                print(e)
+            except Exception:
                 key = None
 
         if key:

--- a/flight_feed_operations/pki_helper.py
+++ b/flight_feed_operations/pki_helper.py
@@ -87,12 +87,6 @@ class MessageVerifier:
                     key_resolver=MyHTTPSignatureKeyResolver(jwk=jwk),
                 )
                 verifier.verify(r)
-                # try:
-                # verifier.verify(request)
-                # except InvalidSignature as i_sig:
-                # logger.error(i_sig)
-                # return False
-
             return True
         else:
             return False

--- a/flight_feed_operations/pki_helper.py
+++ b/flight_feed_operations/pki_helper.py
@@ -1,74 +1,97 @@
-from .models import SignedTelmetryPublicKey
-from http_message_signatures import HTTPMessageSigner, HTTPMessageVerifier, HTTPSignatureKeyResolver, algorithms
-import requests
-from http_message_signatures.exceptions import InvalidSignature
-import jwt
+import hashlib
 import json
-import requests
 import logging
-import hashlib, http_sfv
-from auth_helper.common import get_redis
+from os import environ as env
+
+import http_sfv
+import jwt
+import requests
 from django.core.signing import Signer
+from dotenv import find_dotenv, load_dotenv
+from http_message_signatures import (
+    HTTPMessageVerifier,
+    HTTPSignatureKeyResolver,
+    algorithms,
+)
 from jwcrypto import jwk, jws
 from jwcrypto.common import json_encode
-from os import environ as env
-from dotenv import load_dotenv, find_dotenv
+
+from auth_helper.common import get_redis
+
+from .models import SignedTelmetryPublicKey
+
 load_dotenv(find_dotenv())
 
 
-logger = logging.getLogger('django')
+logger = logging.getLogger("django")
+
 
 class MyHTTPSignatureKeyResolver(HTTPSignatureKeyResolver):
     def __init__(self, jwk):
         self.jwk = jwk
-    def resolve_public_key(self, key_id = None):    
+
+    def resolve_public_key(self, key_id=None):
         public_key = jwt.algorithms.RSAAlgorithm.from_jwk(self.jwk)
         return public_key
-            
 
-class MessageVerifier():
+
+class MessageVerifier:
     def get_public_keys(self):
         r = get_redis()
-        public_keys = {}       
+        public_keys = {}
         s = requests.Session()
-        all_public_keys = SignedTelmetryPublicKey.objects.filter(is_active = 1)
+        all_public_keys = SignedTelmetryPublicKey.objects.filter(is_active=1)
         for current_public_key in all_public_keys:
-            redis_jwks_key = str(current_public_key.id) + '-jwks'
+            redis_jwks_key = str(current_public_key.id) + "-jwks"
             current_kid = current_public_key.key_id
             if r.exists(redis_jwks_key):
                 k = r.get(redis_jwks_key)
                 key = json.loads(k)
-            else:                                
-                response = s.get(current_public_key.url)                
+            else:
+                response = s.get(current_public_key.url)
                 jwks_data = response.json()
-                if 'keys' in jwks_data:                
-                    jwk = next((item for item in jwks_data['keys'] if item['kid'] == current_kid), None)                   
-                else: 
-                    if 'kid' in jwks_data.keys():
-                        jwk = jwks_data if current_kid == jwks_data['kid'] else None
-                    else: 
+                if "keys" in jwks_data:
+                    jwk = next(
+                        (
+                            item
+                            for item in jwks_data["keys"]
+                            if item["kid"] == current_kid
+                        ),
+                        None,
+                    )
+                else:
+                    if "kid" in jwks_data.keys():
+                        jwk = jwks_data if current_kid == jwks_data["kid"] else None
+                    else:
                         jwk = None
-                key = jwk if jwk else {'000'}
-              
+                key = jwk if jwk else {"000"}
+
                 r.set(redis_jwks_key, json.dumps(key))
                 r.expire(redis_jwks_key, 60000)
             public_keys[current_kid] = key
         return public_keys
 
     def verify_message(self, request) -> bool:
-        stored_public_keys=  self.get_public_keys()
-        
-        if bool(stored_public_keys):       
-            r = requests.Request("PUT", request.build_absolute_uri(), json=request.data, headers=request.headers)
-        
-            for key_id, jwk in stored_public_keys.items():  
-                verifier = HTTPMessageVerifier(signature_algorithm = algorithms.RSA_PSS_SHA512, key_resolver = MyHTTPSignatureKeyResolver(jwk= jwk))                
+        stored_public_keys = self.get_public_keys()
+        if bool(stored_public_keys):
+            r = requests.Request(
+                "PUT",
+                request.build_absolute_uri(),
+                json=request.data,
+                headers=request.headers,
+            )
+
+            for key_id, jwk in stored_public_keys.items():
+                verifier = HTTPMessageVerifier(
+                    signature_algorithm=algorithms.RSA_PSS_SHA512,
+                    key_resolver=MyHTTPSignatureKeyResolver(jwk=jwk),
+                )
                 verifier.verify(r)
-                # try: 
+                # try:
                 # verifier.verify(request)
                 # except InvalidSignature as i_sig:
-                    # logger.error(i_sig)
-                    # return False
+                # logger.error(i_sig)
+                # return False
 
             return True
         else:
@@ -76,45 +99,54 @@ class MessageVerifier():
 
 
 class ResponseSigningOperations:
-        
-    def __init__(self):        
-        self.signing_url = env.get('FLIGHT_PASSPORT_SIGNING_URL', None)        
-        self.signing_client_id = env.get('FLIGHT_PASSPORT_SIGNING_CLIENT_ID')
-        self.signing_client_secret = env.get('FLIGHT_PASSPORT_SIGNING_CLIENT_SECRET')
-                
+    def __init__(self):
+        self.signing_url = env.get("FLIGHT_PASSPORT_SIGNING_URL", None)
+        self.signing_client_id = env.get("FLIGHT_PASSPORT_SIGNING_CLIENT_ID")
+        self.signing_client_secret = env.get("FLIGHT_PASSPORT_SIGNING_CLIENT_SECRET")
+
     def generate_content_digest(self, payload):
         payload_str = json.dumps(payload)
-        return str(http_sfv.Dictionary({"sha-256": hashlib.sha256(payload_str.encode('utf-8')).digest()}))
+        return str(
+            http_sfv.Dictionary(
+                {"sha-256": hashlib.sha256(payload_str.encode("utf-8")).digest()}
+            )
+        )
 
-    def sign_json_via_django(self, data_to_sign):      
-
+    def sign_json_via_django(self, data_to_sign):
         signer = Signer()
         signed_obj = signer.sign_object(data_to_sign)
         return signed_obj
-    
-    def sign_json_via_jose(self, payload):
-        '''
-        For a payload sign using the OIDC private key and return signed JWS
-        '''
 
-        algorithms = 'RS256'
-        private_key = env.get('SECRET_KEY', None)
+    def sign_json_via_jose(self, payload):
+        """
+        For a payload sign using the OIDC private key and return signed JWS
+        """
+
+        algorithms = "RS256"
+        private_key = env.get("SECRET_KEY", None)
+        print(private_key)
         if private_key:
             try:
                 key = jwk.JWK.from_pem(private_key.encode("utf8"))
-            except Exception as e: 
+            except Exception as e:
+                print(e)
                 key = None
 
         if key:
             payload_str = json.dumps(payload)
-            jws_token = jws.JWS(payload = payload_str)
-            
-            jws_token.add_signature(key = key, alg=algorithms, protected= json_encode({"alg":"RS256","kid": key.thumbprint()}))
-            
-            sig = jws_token.serialize()
-            s= json.loads(sig)
-            
-            return {"signature": s["protected"]+'.'+s["payload"]+'.'+s["signature"]}
-        else: 
-            return {}
+            jws_token = jws.JWS(payload=payload_str)
 
+            jws_token.add_signature(
+                key=key,
+                alg=algorithms,
+                protected=json_encode({"alg": "RS256", "kid": key.thumbprint()}),
+            )
+
+            sig = jws_token.serialize()
+            s = json.loads(sig)
+
+            return {
+                "signature": s["protected"] + "." + s["payload"] + "." + s["signature"]
+            }
+        else:
+            return {}

--- a/flight_feed_operations/views.py
+++ b/flight_feed_operations/views.py
@@ -249,7 +249,7 @@ def set_signed_telemetry(request):
             unsigned_telemetry_observations.append(asdict(single_observation_set, dict_factory=NestedDict))
 
             stream_rid_data_v22.delay(rid_telemetry_observations= json.dumps(unsigned_telemetry_observations))
-        submission_success = {"message": "Telemetry data succesfully submitted"}
+        submission_success = {"message": "Telemetry data successfully submitted"}
         content_digest = my_response_signer.generate_content_digest(submission_success)       
         signed_data = my_response_signer.sign_json_via_django(submission_success)              
         submission_success['signed'] = signed_data


### PR DESCRIPTION
## Proposed changes

Describe the big picture of the code changes here to the team. If it fixes a bug or resolves a feature request, be sure to add the JIRA link to that issue.

## Types of changes
[JIRA](https://ssrc.atlassian.net/browse/SCUTM-292)

Extracted the logic inside the big function `set_flight_declaration` so that we can reuse it when we implement `signed_set_flight_declaration`: Supports non-repudiation.

Previously the code logics of:

-  _parsing JSON payload_, 
- _getting Operational Intent_ 
- _sending RABBITMQ messages_ were bundled together.

Extracted 3 private methods from above code so that we can reuse the same code when implementing `POST signed_set_flight_declaration`

Extracted 3 functions are:

- _parse_flight_declaration_request()
- _get_operational_intent()
- _send_fd_creation_notifications()

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with the changes
- [x] Added new tests that prove the changes in this PR works
- [ ] Added necessary documentation (if appropriate)
- [ ] Added copyrights to new files (if appropriate)

## Further comments

_Add special comments about the changes here if required._