### PR TITLE
Added states filter to the FlighPlans filter query

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -66,6 +66,7 @@ def create_flight_plan(db) -> None:
         type_of_operation=1,
         submitted_by="User 001",
         is_approved=False,
+        state=1,
         start_datetime=flight_s_time,
         end_datetime=flight_e_time,
         originating_party="Party 001",
@@ -148,9 +149,10 @@ def create_flight_plan(db) -> None:
         type_of_operation=1,
         submitted_by="User 002",
         is_approved=False,
+        state=2,
         start_datetime=flight_s_time,
         end_datetime=flight_e_time,
-        originating_party="PArty 002",
+        originating_party="Party 002",
         flight_declaration_raw_geojson=json.dumps(
             {
                 "type": "FeatureCollection",
@@ -229,6 +231,7 @@ def create_flight_plan(db) -> None:
         type_of_operation=1,
         submitted_by="User 003",
         is_approved=False,
+        state=3,
         start_datetime=flight_s_time,
         end_datetime=flight_e_time,
         originating_party="Party 003",

--- a/flight_declaration_operations/test_views.py
+++ b/flight_declaration_operations/test_views.py
@@ -274,3 +274,30 @@ class FlightDeclarationGetTests(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["total"], 3)
+
+
+    def test_count_flight_plans_with_datetime_filter_2(self):
+        flight_s_time = "2023-08-01 09:30:00"
+        flight_e_time = "2023-08-01 12:30:00"
+        response = self.client.get(
+            self.api_url
+            + "?start_date={flight_s_time}&end_date={flight_e_time}".format(
+                flight_s_time=flight_s_time, flight_e_time=flight_e_time
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["total"], 2)
+
+    def test_count_flight_plans_with_datetime_filter_3(self):
+        flight_s_time = "2023-08-01 15:30:00"
+        flight_e_time = "2023-08-01 17:00:00"
+        response = self.client.get(
+            self.api_url
+            + "?start_date={flight_s_time}&end_date={flight_e_time}".format(
+                flight_s_time=flight_s_time, flight_e_time=flight_e_time
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["total"], 1)

--- a/flight_declaration_operations/test_views.py
+++ b/flight_declaration_operations/test_views.py
@@ -275,7 +275,6 @@ class FlightDeclarationGetTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["total"], 3)
 
-
     def test_count_flight_plans_with_datetime_filter_2(self):
         flight_s_time = "2023-08-01 09:30:00"
         flight_e_time = "2023-08-01 12:30:00"
@@ -301,3 +300,59 @@ class FlightDeclarationGetTests(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["total"], 1)
+
+    def test_count_flight_plans_with_state_filter_1(self):
+        flight_s_time = "2023-08-01 00:00:00"
+        flight_e_time = "2023-08-01 23:00:00"
+        response = self.client.get(
+            self.api_url
+            + "?states=1,2,3,4,5"
+            + "&start_date={flight_s_time}&end_date={flight_e_time}".format(
+                flight_s_time=flight_s_time, flight_e_time=flight_e_time
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["total"], 3)
+
+    def test_count_flight_plans_with_state_filter_2(self):
+        flight_s_time = "2023-08-01 00:00:00"
+        flight_e_time = "2023-08-01 23:00:00"
+        response = self.client.get(
+            self.api_url
+            + "?states=2,3"
+            + "&start_date={flight_s_time}&end_date={flight_e_time}".format(
+                flight_s_time=flight_s_time, flight_e_time=flight_e_time
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["total"], 2)
+
+    def test_count_flight_plans_with_state_filter_3(self):
+        flight_s_time = "2023-08-01 00:00:00"
+        flight_e_time = "2023-08-01 23:00:00"
+        response = self.client.get(
+            self.api_url
+            + "?states=3"
+            + "&start_date={flight_s_time}&end_date={flight_e_time}".format(
+                flight_s_time=flight_s_time, flight_e_time=flight_e_time
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["total"], 1)
+
+    def test_count_flight_plans_with_state_filter_4(self):
+        flight_s_time = "2023-08-01 00:00:00"
+        flight_e_time = "2023-08-01 23:00:00"
+        response = self.client.get(
+            self.api_url
+            + "?states=4,5"
+            + "&start_date={flight_s_time}&end_date={flight_e_time}".format(
+                flight_s_time=flight_s_time, flight_e_time=flight_e_time
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["total"], 0)

--- a/flight_declaration_operations/views.py
+++ b/flight_declaration_operations/views.py
@@ -343,6 +343,7 @@ class FlightDeclarationList(mixins.ListModelMixin, generics.GenericAPIView):
         view_port: List[float],
         max_alt: int = None,
         min_alt: int = None,
+        states: List[int] = None,
     ):
         filter_query = Q()
         if start_date and end_date:
@@ -403,7 +404,14 @@ class FlightDeclarationList(mixins.ListModelMixin, generics.GenericAPIView):
                 ),
                 Q.AND,
             )
-
+        if states:
+            filter_query.add(
+                Q(
+                    state__in=states
+                ),
+                Q.AND,
+            )
+        
         filtered = FlightDeclaration.objects.filter(filter_query)
         return filtered
 
@@ -415,6 +423,11 @@ class FlightDeclarationList(mixins.ListModelMixin, generics.GenericAPIView):
         min_alt = self.request.query_params.get("min_alt", None)
 
         view = self.request.query_params.get("view", None)
+        state_str = self.request.query_params.get('states')
+
+        states = []
+        if state_str:
+            states = state_str.split(',')
         view_port = []
         if view:
             view_port = [float(i) for i in view.split(",")]
@@ -425,6 +438,7 @@ class FlightDeclarationList(mixins.ListModelMixin, generics.GenericAPIView):
             end_date=end_date,
             max_alt=max_alt,
             min_alt=min_alt,
+            states=states,
         )
         return responses
 

--- a/flight_declaration_operations/views.py
+++ b/flight_declaration_operations/views.py
@@ -1,5 +1,6 @@
 # Create your views here.
 import io
+
 # Create your views here.
 import json
 import logging
@@ -20,16 +21,16 @@ from geo_fence_operations import rtree_geo_fence_helper
 from geo_fence_operations.models import GeoFence
 
 from .data_definitions import FlightDeclarationCreateResponse
-from .flight_declarations_rtree_helper import \
-    FlightDeclarationRTreeIndexFactory
+from .flight_declarations_rtree_helper import FlightDeclarationRTreeIndexFactory
 from .models import FlightDeclaration
 from .pagination import StandardResultsSetPagination
-from .serializers import (FlightDeclarationApprovalSerializer,
-                          FlightDeclarationRequestSerializer,
-                          FlightDeclarationSerializer,
-                          FlightDeclarationStateSerializer)
-from .tasks import (send_operational_update_message,
-                    submit_flight_declaration_to_dss)
+from .serializers import (
+    FlightDeclarationApprovalSerializer,
+    FlightDeclarationRequestSerializer,
+    FlightDeclarationSerializer,
+    FlightDeclarationStateSerializer,
+)
+from .tasks import send_operational_update_message, submit_flight_declaration_to_dss
 from .utils import OperationalIntentsConverter
 
 logger = logging.getLogger("django")
@@ -355,24 +356,24 @@ class FlightDeclarationList(mixins.ListModelMixin, generics.GenericAPIView):
             s_date = present.shift(days=-1)
             e_date = present.shift(days=1)
 
-        all_fd_within_timelimits = FlightDeclaration.objects.filter(
-            start_datetime__gte=s_date.isoformat(), end_datetime__lte=e_date.isoformat()
+        all_fd_overlaps_timelimits = FlightDeclaration.objects.filter(
+            end_datetime__gte=s_date.isoformat(), start_datetime__lte=e_date.isoformat()
         )
         filter_query.add(
             Q(
-                start_datetime__gte=s_date.isoformat(),
-                end_datetime__lte=e_date.isoformat(),
+                end_datetime__gte=s_date.isoformat(),
+                start_datetime__lte=e_date.isoformat(),
             ),
             Q.AND,
         )
 
-        logging.info("Found %s flight declarations" % len(all_fd_within_timelimits))
+        logging.info("Found %s flight declarations" % len(all_fd_overlaps_timelimits))
 
         if view_port:
             INDEX_NAME = "opint_idx"
             my_rtree_helper = FlightDeclarationRTreeIndexFactory(index_name=INDEX_NAME)
             my_rtree_helper.generate_flight_declaration_index(
-                all_flight_declarations=all_fd_within_timelimits
+                all_flight_declarations=all_fd_overlaps_timelimits
             )
 
             all_relevant_fences = my_rtree_helper.check_box_intersection(
@@ -406,12 +407,10 @@ class FlightDeclarationList(mixins.ListModelMixin, generics.GenericAPIView):
             )
         if states:
             filter_query.add(
-                Q(
-                    state__in=states
-                ),
+                Q(state__in=states),
                 Q.AND,
             )
-        
+
         filtered = FlightDeclaration.objects.filter(filter_query)
         return filtered
 
@@ -423,11 +422,11 @@ class FlightDeclarationList(mixins.ListModelMixin, generics.GenericAPIView):
         min_alt = self.request.query_params.get("min_alt", None)
 
         view = self.request.query_params.get("view", None)
-        state_str = self.request.query_params.get('states')
+        state_str = self.request.query_params.get("states")
 
         states = []
         if state_str:
-            states = state_str.split(',')
+            states = state_str.split(",")
         view_port = []
         if view:
             view_port = [float(i) for i in view.split(",")]


### PR DESCRIPTION
## Proposed changes

- Added a new query parameter `states` to filter the fligh plans based on the state column's value.
- Changed datetime filter to consider flights that `touches` the given time period, not the flights that are `within` the time period

Example endpoint request with states filter t: `/flight_declaration?start_date=2023-08-01 15:00:00&end_date=2023-08-31 16:30:45&states=1,2,3,4,5`

Query parameter **states** accepts an array of states as below:
states=1
states=1,2
states=1,2,3
states=1,2,3,4,5

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with the changes
- [x] Added new tests that prove the changes in this PR works
- [ ] Added necessary documentation (if appropriate)
- [ ] Added copyrights to new files (if appropriate)

## Further comments