### PR TITLE
Change FB creation HTTP response code from 200 to 202

### DIFF
--- a/flight_declaration_operations/test_views.py
+++ b/flight_declaration_operations/test_views.py
@@ -199,7 +199,7 @@ class FlightDeclarationPostTests(APITestCase):
             data=json.dumps(valid_payload),
         )
         self.assertEqual(response.json()["message"], "Submitted Flight Declaration")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
 
 @pytest.mark.usefixtures("create_flight_plan")

--- a/flight_declaration_operations/views.py
+++ b/flight_declaration_operations/views.py
@@ -290,8 +290,9 @@ def set_flight_declaration(request: HttpRequest):
     )
 
     op = json.dumps(asdict(creation_response))
-    # TODO: Should the return status code be 201 since it creates a new record?
-    return HttpResponse(op, status=status.HTTP_200_OK, content_type="application/json")
+    return HttpResponse(
+        op, status=status.HTTP_201_CREATED, content_type="application/json"
+    )
 
 
 @api_view(["POST"])


### PR DESCRIPTION
## Proposed changes

Changed the HTTP response code of `POST /flight_declaration_ops/set_flight_declaration` from **HTTP 200 OK** to **201 Creation**

❗ Note: In `USSP-link`, we have to change this line to capture 201 also: https://github.com/tiiuae/drone-utm/blob/main/pkg/blender/blender.go#L222

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with the changes
- [ ] Added new tests that prove the changes in this PR works
- [ ] Added necessary documentation (if appropriate)
- [ ] Added copyrights to new files (if appropriate)

## Further comments

_Add special comments about the changes here if required._