### PR TITLE
Set telemetry endpoint refactored for better efficiency+readability

### DIFF
--- a/encoders.py
+++ b/encoders.py
@@ -1,0 +1,9 @@
+import json
+from datetime import datetime
+
+
+class DateTimeEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        return super().default(obj)

--- a/flight_feed_operations/rid_telemetry_helper.py
+++ b/flight_feed_operations/rid_telemetry_helper.py
@@ -1,8 +1,15 @@
-
-from typing import List
-from dacite import from_dict
-from rid_operations.data_definitions import SubmittedTelemetryFlightDetails, SignedTelemetryRequest, RIDFlightDetails, RIDAircraftState, SignedUnSignedTelemetryObservations, Time, RIDOperationalStatus, RIDAircraftPosition, HorizontalAccuracy, VerticalAccuracy, RIDHeight, SpeedAccuracy, UAClassificationEU, UASID, OperatorLocation, LatLngPoint, RIDAuthData
 from enum import Enum
+from typing import List
+
+from dacite import from_dict
+
+from rid_operations.data_definitions import (
+    UASID, HorizontalAccuracy, LatLngPoint, OperatorLocation,
+    RIDAircraftPosition, RIDAircraftState, RIDAuthData, RIDFlightDetails,
+    RIDHeight, RIDOperationalStatus, SignedTelemetryRequest,
+    SignedUnSignedTelemetryObservations, SpeedAccuracy,
+    SubmittedTelemetryFlightDetails, Time, UAClassificationEU,
+    VerticalAccuracy)
 
 
 class NestedDict(dict):
@@ -12,65 +19,90 @@ class NestedDict(dict):
         return obj
 
     def __init__(self, data):
-        super().__init__(self.convert_value(x)
-                         for x in data if x[1] is not None)
+        super().__init__(self.convert_value(x) for x in data if x[1] is not None)
 
 
-def generate_rid_telemetry_objects(signed_telemetry_request: SignedTelemetryRequest) -> List[SubmittedTelemetryFlightDetails]:
+def generate_rid_telemetry_objects(
+    signed_telemetry_request: SignedTelemetryRequest,
+) -> List[SubmittedTelemetryFlightDetails]:
     all_rid_data = []
 
     for current_signed_telemetry_request in signed_telemetry_request:
-
         s = from_dict(
             data_class=SubmittedTelemetryFlightDetails,
-            data=current_signed_telemetry_request)
+            data=current_signed_telemetry_request,
+        )
         all_rid_data.append(s)
 
     return all_rid_data
 
 
-def generate_unsigned_rid_telemetry_objects(telemetry_request: List[SignedUnSignedTelemetryObservations]) -> List[SubmittedTelemetryFlightDetails]:
+def generate_unsigned_rid_telemetry_objects(
+    telemetry_request: List[SignedUnSignedTelemetryObservations],
+) -> List[SubmittedTelemetryFlightDetails]:
     all_rid_data = []
 
     for current_unsigned_telemetry_request in telemetry_request:
-
         s = from_dict(
             data_class=SubmittedTelemetryFlightDetails,
-            data=current_unsigned_telemetry_request)
+            data=current_unsigned_telemetry_request,
+        )
         all_rid_data.append(s)
 
     return all_rid_data
 
-
-class BlenderTelemetryValidator():
-
+#TODO: Delete the usage of this
+class BlenderTelemetryValidator:
     def parse_validate_current_state(self, current_state) -> RIDAircraftState:
-
         timestamp = Time(
-            value=current_state['timestamp']['value'], format=current_state['timestamp']['format'])
-        operational_status = RIDOperationalStatus(
-            current_state['operational_status'])
-        _state_position = current_state['position']
+            value=current_state["timestamp"]["value"],
+            format=current_state["timestamp"]["format"],
+        )
+        operational_status = RIDOperationalStatus(current_state["operational_status"])
+        _state_position = current_state["position"]
         # In provided telemetry position and pressure altitude and extrapolated values are optional use if provided else generate them.
-        pressure_altitude = _state_position['pressure_altitude'] if 'pressure_altitude' in _state_position else 0.0
-        extrapolated = _state_position['extrapolated'] if 'extrapolated' in _state_position else 0
+        pressure_altitude = (
+            _state_position["pressure_altitude"]
+            if "pressure_altitude" in _state_position
+            else 0.0
+        )
+        extrapolated = (
+            _state_position["extrapolated"] if "extrapolated" in _state_position else 0
+        )
 
-        accuracy_h = HorizontalAccuracy(value=_state_position['accuracy_h'])
-        accuracy_v = VerticalAccuracy(value=_state_position['accuracy_v'])
+        accuracy_h = HorizontalAccuracy(value=_state_position["accuracy_h"])
+        accuracy_v = VerticalAccuracy(value=_state_position["accuracy_v"])
         height = RIDHeight(
-            reference=current_state['height']['reference'], distance=current_state['height']['distance'])
+            reference=current_state["height"]["reference"],
+            distance=current_state["height"]["distance"],
+        )
 
-        position = RIDAircraftPosition(pressure_altitude=pressure_altitude, lat=_state_position['lat'], lng=_state_position[
-                                       'lng'], accuracy_h=accuracy_h, accuracy_v=accuracy_v, extrapolated=extrapolated, height=height)
-        speed_accuracy = SpeedAccuracy('SA3mps')
+        position = RIDAircraftPosition(
+            pressure_altitude=pressure_altitude,
+            lat=_state_position["lat"],
+            lng=_state_position["lng"],
+            accuracy_h=accuracy_h,
+            accuracy_v=accuracy_v,
+            extrapolated=extrapolated,
+            height=height,
+        )
+        speed_accuracy = SpeedAccuracy("SA3mps")
 
-        s = RIDAircraftState(timestamp=timestamp, operational_status=operational_status, position=position,  track=current_state['track'], speed=current_state[
-                             'speed'], timestamp_accuracy=current_state['timestamp_accuracy'], speed_accuracy=speed_accuracy, vertical_speed=current_state['vertical_speed'])
+        s = RIDAircraftState(
+            timestamp=timestamp,
+            operational_status=operational_status,
+            position=position,
+            track=current_state["track"],
+            speed=current_state["speed"],
+            timestamp_accuracy=current_state["timestamp_accuracy"],
+            speed_accuracy=speed_accuracy,
+            vertical_speed=current_state["vertical_speed"],
+        )
 
         return s
 
     def parse_validate_current_states(self, current_states) -> List[RIDAircraftState]:
-        ''' This method parses and validates current state object and returns a dataclass  '''
+        """This method parses and validates current state object and returns a dataclass"""
 
         all_states = []
 
@@ -80,59 +112,153 @@ class BlenderTelemetryValidator():
         return all_states
 
     def parse_validate_rid_details(self, rid_flight_details) -> RIDFlightDetails:
-
-        if 'eu_classification' in rid_flight_details.keys():
-            eu_classification_details = rid_flight_details['eu_classification']
+        if "eu_classification" in rid_flight_details.keys():
+            eu_classification_details = rid_flight_details["eu_classification"]
             eu_classification = UAClassificationEU(
-                category=eu_classification_details['category'], class_=eu_classification_details['class_'])
+                category=eu_classification_details["category"],
+                class_=eu_classification_details["class_"],
+            )
         else:
             eu_classification = UAClassificationEU(category="", class_="")
-        if 'uas_id' in rid_flight_details.keys():
-            uas_id_details = rid_flight_details['uas_id']
-            uas_id = UASID(serial_number=uas_id_details['serial_number'],
-                           registration_id=uas_id_details['registration_id'], utm_id=uas_id_details['utm_id'])
+        if "uas_id" in rid_flight_details.keys():
+            uas_id_details = rid_flight_details["uas_id"]
+            uas_id = UASID(
+                serial_number=uas_id_details["serial_number"],
+                registration_id=uas_id_details["registration_id"],
+                utm_id=uas_id_details["utm_id"],
+            )
         else:
-            uas_id = UASID(serial_number="",
-                           registration_id="", utm_id="")
-        if 'operator_location' in rid_flight_details.keys():
-
-            if 'position' in rid_flight_details['operator_location']:
-                o_location_position = rid_flight_details['operator_location']['position']
+            uas_id = UASID(serial_number="", registration_id="", utm_id="")
+        if "operator_location" in rid_flight_details.keys():
+            if "position" in rid_flight_details["operator_location"]:
+                o_location_position = rid_flight_details["operator_location"][
+                    "position"
+                ]
                 operator_position = LatLngPoint(
-                    lat=o_location_position['lat'], lng=o_location_position['lng'])
-                operator_location = OperatorLocation(
-                    position=operator_position)
+                    lat=o_location_position["lat"], lng=o_location_position["lng"]
+                )
+                operator_location = OperatorLocation(position=operator_position)
             else:
                 operator_location = OperatorLocation(
-                    position=LatLngPoint(lat="", lng=""))
+                    position=LatLngPoint(lat="", lng="")
+                )
         else:
-            operator_location = OperatorLocation(
-                position=LatLngPoint(lat="", lng=""))
+            operator_location = OperatorLocation(position=LatLngPoint(lat="", lng=""))
         auth_data = RIDAuthData(format=0, data="")
-        if 'auth_data' in rid_flight_details.keys():
+        if "auth_data" in rid_flight_details.keys():
             auth_data = RIDAuthData(format="", data="")
-            if rid_flight_details['auth_data'] is not None:
+            if rid_flight_details["auth_data"] is not None:
                 # auth_data = RIDAuthData(
                 # format=rid_flight_details['auth_data']['format'], data=rid_flight_details['auth_data']['data'])
-                auth_data.format = rid_flight_details['auth_data']['format']
-                auth_data.data = rid_flight_details['auth_data']['data']
+                auth_data.format = rid_flight_details["auth_data"]["format"]
+                auth_data.data = rid_flight_details["auth_data"]["data"]
 
-        f_details = RIDFlightDetails(id=rid_flight_details['id'], eu_classification=eu_classification, uas_id=uas_id, operator_location=operator_location,
-                                     operator_id=rid_flight_details['operator_id'], operation_description=rid_flight_details['operation_description'], auth_data=auth_data)
+        f_details = RIDFlightDetails(
+            id=rid_flight_details["id"],
+            eu_classification=eu_classification,
+            uas_id=uas_id,
+            operator_location=operator_location,
+            operator_id=rid_flight_details["operator_id"],
+            operation_description=rid_flight_details["operation_description"],
+            auth_data=auth_data,
+        )
 
         return f_details
 
     def validate_flight_details_current_states_exist(self, flight) -> bool:
         try:
-            assert 'flight_details' in flight
-            assert 'current_states' in flight
+            assert "flight_details" in flight
+            assert "current_states" in flight
         except AssertionError as ae:
             return False
         return True
 
     def validate_observation_key_exists(self, raw_request_data) -> bool:
         try:
-            assert 'observations' in raw_request_data
+            assert "observations" in raw_request_data
         except AssertionError as ae:
             return False
         return True
+
+
+def flight_detail_json_to_object(json) -> RIDFlightDetails:
+    eu_classification_details = json["eu_classification"]
+    eu_classification = UAClassificationEU(
+        category=eu_classification_details["category"],
+        class_=eu_classification_details["class_"],
+    )
+
+    uas_id_details = json["uas_id"]
+    uas_id = UASID(
+        serial_number=uas_id_details["serial_number"],
+        registration_id=uas_id_details["registration_id"],
+        utm_id=uas_id_details["utm_id"],
+    )
+
+    o_location_position = json["operator_location"]["position"]
+    operator_position = LatLngPoint(
+        lat=o_location_position["lat"], lng=o_location_position["lng"]
+    )
+    operator_location = OperatorLocation(position=operator_position)
+
+    auth_data = RIDAuthData(
+        format=json["auth_data"]["format"],
+        data=json["auth_data"]["data"],
+    )
+
+    f_details = RIDFlightDetails(
+        id=json["rid_details"]["id"],
+        eu_classification=eu_classification,
+        uas_id=uas_id,
+        operator_location=operator_location,
+        operator_id=json["rid_details"]["operator_id"],
+        operation_description=json["rid_details"]["operation_description"],
+        auth_data=auth_data,
+    )
+
+    return f_details
+
+
+def current_state_json_to_object(json) -> RIDAircraftState:
+    timestamp = Time(
+        value=json["timestamp"]["value"],
+        format=json["timestamp"]["format"],
+    )
+    operational_status = RIDOperationalStatus(json["operational_status"])
+    _state_position = json["position"]
+    # In provided telemetry position and pressure altitude and extrapolated values are optional use if provided else generate them.
+    pressure_altitude = _state_position["pressure_altitude"]
+    extrapolated = (
+        _state_position["extrapolated"] if "extrapolated" in _state_position else 0
+    )
+
+    accuracy_h = HorizontalAccuracy(value=_state_position["accuracy_h"])
+    accuracy_v = VerticalAccuracy(value=_state_position["accuracy_v"])
+    height = RIDHeight(
+        reference=json["height"]["reference"],
+        distance=json["height"]["distance"],
+    )
+
+    position = RIDAircraftPosition(
+        pressure_altitude=pressure_altitude,
+        lat=_state_position["lat"],
+        lng=_state_position["lng"],
+        accuracy_h=accuracy_h,
+        accuracy_v=accuracy_v,
+        extrapolated=extrapolated,
+        height=height,
+    )
+    speed_accuracy = SpeedAccuracy("SA3mps")
+
+    current_state = RIDAircraftState(
+        timestamp=timestamp,
+        operational_status=operational_status,
+        position=position,
+        track=json["track"],
+        speed=json["speed"],
+        timestamp_accuracy=json["timestamp_accuracy"],
+        speed_accuracy=speed_accuracy,
+        vertical_speed=json["vertical_speed"],
+    )
+
+    return current_state

--- a/flight_feed_operations/rid_telemetry_helper.py
+++ b/flight_feed_operations/rid_telemetry_helper.py
@@ -180,7 +180,6 @@ class BlenderTelemetryValidator:
             return False
         return True
 
-
 def flight_detail_json_to_object(json) -> RIDFlightDetails:
     eu_classification_details = json["eu_classification"]
     eu_classification = UAClassificationEU(
@@ -217,7 +216,6 @@ def flight_detail_json_to_object(json) -> RIDFlightDetails:
     )
 
     return f_details
-
 
 def current_state_json_to_object(json) -> RIDAircraftState:
     timestamp = Time(

--- a/flight_feed_operations/serializers.py
+++ b/flight_feed_operations/serializers.py
@@ -8,3 +8,16 @@ class SignedTelmetryPublicKeySerializer(serializers.ModelSerializer):
         model = SignedTelmetryPublicKey        
         fields = ('key_id','url', 'is_active',)
    
+
+
+class CurrentStateSerializer(serializers.Serializer):
+    # Define fields for the "current_states" object if needed
+    pass
+
+class FlightDetailsSerializer(serializers.Serializer):
+    # Define fields for the "flight_details" object if needed
+    pass
+
+class ObservationSerializer(serializers.Serializer):
+    current_states = CurrentStateSerializer(many=True)
+    flight_details = FlightDetailsSerializer()

--- a/flight_feed_operations/serializers.py
+++ b/flight_feed_operations/serializers.py
@@ -79,7 +79,9 @@ class ObservationSerializer(serializers.Serializer):
     flight_details = FlightDetailsSerializer()
 
 class TelemetryRequestSerializer(serializers.Serializer):
-    observations = ObservationSerializer(many=True)
+    observations = ObservationSerializer(many=True,        error_messages={
+            "required": "A flight observation array with current states and flight details is necessary"
+        })
 
     def create(self, validated_data):
         return TelemetryRequest(**validated_data)

--- a/flight_feed_operations/serializers.py
+++ b/flight_feed_operations/serializers.py
@@ -80,3 +80,19 @@ class ObservationSerializer(serializers.Serializer):
 
 class TelemetryRequestSerializer(serializers.Serializer):
     observations = ObservationSerializer(many=True)
+
+    def create(self, validated_data):
+        return TelemetryRequest(**validated_data)
+
+
+
+class TelemetryRequest:
+    """
+    Class object that will be used to contain deserialized JSON payload from the POST request.
+    """
+
+    def __init__(
+        self,
+        observations,
+    ):
+        self.observations = observations

--- a/flight_feed_operations/serializers.py
+++ b/flight_feed_operations/serializers.py
@@ -1,23 +1,82 @@
 from rest_framework import serializers
-import json
 from .models import SignedTelmetryPublicKey
-
+from rid_operations import data_definitions as rid_dd
 class SignedTelmetryPublicKeySerializer(serializers.ModelSerializer):
     
     class Meta:
         model = SignedTelmetryPublicKey        
         fields = ('key_id','url', 'is_active',)
    
+class TimestampSerializer(serializers.Serializer):
+    value = serializers.DateTimeField(format="%Y-%m-%dT%H:%M:%S.%fZ")
+    format = serializers.CharField(required=False,default = 'RFC3339')
 
+class PositionSerializer(serializers.Serializer):
+    lat = serializers.FloatField(required=False,default=0.0)
+    lng = serializers.FloatField(required=False,default=0.0)
+    alt = serializers.FloatField(required=False,default=0.0)
+    accuracy_h = serializers.ChoiceField(choices=[(choice.value, choice.name) for choice in rid_dd.HorizontalAccuracy])
+    accuracy_v = serializers.ChoiceField(choices=[(choice.value, choice.name) for choice in rid_dd.VerticalAccuracy])
+    extrapolated = serializers.BooleanField(required=False,default=False)
+    pressure_altitude = serializers.FloatField(required=False,default=0.0)
+
+class HeightSerializer(serializers.Serializer):
+    distance = serializers.FloatField()
+    reference = serializers.CharField()
 
 class CurrentStateSerializer(serializers.Serializer):
-    # Define fields for the "current_states" object if needed
-    pass
+    timestamp = TimestampSerializer()
+    timestamp_accuracy = serializers.FloatField()
+    operational_status = serializers.ChoiceField(choices=[(choice.value, choice.name) for choice in rid_dd.RIDOperationalStatus])
+    position = PositionSerializer()
+    track = serializers.FloatField()
+    speed = serializers.FloatField()
+    speed_accuracy = serializers.ChoiceField(choices=[(choice.value, choice.name) for choice in rid_dd.SpeedAccuracy])
+    vertical_speed = serializers.FloatField()
+    height = HeightSerializer()
+    group_radius = serializers.FloatField(required=False)
+    group_ceiling = serializers.FloatField(required=False)
+    group_floor = serializers.FloatField(required=False)
+    group_count = serializers.IntegerField(required=False)
+    group_time_start = serializers.DateTimeField(required=False,format="%Y-%m-%dT%H:%M:%S.%fZ")
+    group_time_end = serializers.DateTimeField(required=False,format="%Y-%m-%dT%H:%M:%S.%fZ")
+
+class RidDetailsSerializer(serializers.Serializer):
+    id = serializers.CharField()
+    operator_id = serializers.CharField()
+    operation_description = serializers.CharField()
+
+class EuClassificationSerializer(serializers.Serializer):
+    category = serializers.CharField(required=False,default='EUCategoryUndefined')
+    class_ = serializers.CharField(required=False,default='EUClassUndefined')
+
+class UasIdSerializer(serializers.Serializer):
+    serial_number = serializers.CharField(required=False,default="")
+    registration_id = serializers.CharField(required=False,default="")
+    utm_id = serializers.CharField(required=False,default="")
+    specific_session_id = serializers.CharField(required=False,default=None)
+
+class OperatorLocationSerializer(serializers.Serializer):
+    position = PositionSerializer()
+    altitude = serializers.FloatField()
+    altitude_type = serializers.CharField()
+
+class AuthDataSerializer(serializers.Serializer):
+    format = serializers.CharField(required=False,default="")
+    data = serializers.IntegerField(required=False,default=0)
 
 class FlightDetailsSerializer(serializers.Serializer):
-    # Define fields for the "flight_details" object if needed
-    pass
+    rid_details = RidDetailsSerializer()
+    eu_classification = EuClassificationSerializer()
+    uas_id = UasIdSerializer()
+    operator_location = OperatorLocationSerializer()
+    auth_data = AuthDataSerializer()
+    serial_number = serializers.CharField()
+    registration_number = serializers.CharField()
 
 class ObservationSerializer(serializers.Serializer):
     current_states = CurrentStateSerializer(many=True)
     flight_details = FlightDetailsSerializer()
+
+class TelemetryRequestSerializer(serializers.Serializer):
+    observations = ObservationSerializer(many=True)

--- a/flight_feed_operations/test_views.py
+++ b/flight_feed_operations/test_views.py
@@ -1,0 +1,231 @@
+"""
+This file contains unit tests for the views functions in flight_feed_operations
+"""
+import datetime
+import json
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+JWT = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0ZXN0ZmxpZ2h0LmZsaWdodGJsZW5kZXIuY29tIiwiY2xpZW50X2lkIjoidXNzX25vYXV0aCIsImV4cCI6MTY4Nzc4Mjk0OCwiaXNzIjoiTm9BdXRoIiwianRpIjoiODI0OWI5ODgtZjlkZi00YmNhLWI2YTctODVhZGFiZjFhMTUwIiwibmJmIjoxNjg3Nzc5MzQ3LCJzY29wZSI6ImJsZW5kZXIucmVhZCIsInN1YiI6InVzc19ub2F1dGgifQ.b63qZWs08Cp1cgfRCtbQfLom6QQyFpqUaFDNZ9ZdAjSM690StACij6FiriSFhOfFiRBv9rE0DePJzElUSwv1r1bI0IpKMtEJYsJY4DXy7ZImiJ3rSten1nnb1LLAELcDIxMZM2D1ek43EFW35al4si640JfMcSmt62bEP1b4Msc"
+
+
+class TelemetryPostTests(APITestCase):
+    """
+    Contains tests for the function set_telemetry in views.
+    """
+
+    def setUp(self):
+        self.client.defaults["HTTP_AUTHORIZATION"] = "Bearer " + JWT
+        self.api_url = reverse("set_telemetry")
+
+    def test_empty_payload(self):
+        empty_payload = {}
+        response = self.client.put(
+            self.api_url, content_type="application/json", data=empty_payload
+        )
+        response_json = {
+            "observations": [
+                "A flight observation array with current states and flight details is necessary"
+            ]
+        }
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json(), response_json)
+
+    def test_valid_payload(self):
+        payload = {
+            "observations": [
+                {
+                    "current_states": [
+                        {
+                            "timestamp": {
+                                "value": "1985-04-12T23:20:50.52Z",
+                                "format": "RFC3339",
+                            },
+                            "timestamp_accuracy": 0,
+                            "operational_status": "Undeclared",
+                            "position": {
+                                "lat": 34.12,
+                                "lng": -118.456,
+                                "alt": 1321.2,
+                                "accuracy_h": "HAUnknown",
+                                "accuracy_v": "VAUnknown",
+                                "extrapolated": True,
+                                "pressure_altitude": 0,
+                            },
+                            "track": 0,
+                            "speed": 1.9,
+                            "speed_accuracy": "SAUnknown",
+                            "vertical_speed": 0.2,
+                            "height": {"distance": 0, "reference": "TakeoffLocation"},
+                            "group_radius": 0,
+                            "group_ceiling": 0,
+                            "group_floor": 0,
+                            "group_count": 1,
+                            "group_time_start": "2019-08-24T14:15:22Z",
+                            "group_time_end": "2019-08-24T14:15:22Z",
+                        }
+                    ],
+                    "flight_details": {
+                        "rid_details": {
+                            "id": "a3423b-213401-0023",
+                            "operator_id": "N.OP123456",
+                            "operation_description": "SafeFlightDrone company doing survey with DJI Inspire 2. See my privacy policy www.example.com/privacy.",
+                        },
+                        "eu_classification": {
+                            "category": "EUCategoryUndefined",
+                            "class": "EUClassUndefined",
+                        },
+                        "uas_id": {
+                            "serial_number": "INTCJ123-4567-890",
+                            "registration_id": "N.123456",
+                            "utm_id": "ae1fa066-6d68-4018-8274-af867966978e",
+                            "specific_session_id": "02-a1b2c3d4e5f60708",
+                        },
+                        "operator_location": {
+                            "position": {
+                                "lng": -118.456,
+                                "lat": 34.12,
+                                "accuracy_h": "HAUnknown",
+                                "accuracy_v": "VAUnknown",
+                            },
+                            "altitude": 19.5,
+                            "altitude_type": "Takeoff",
+                        },
+                        "auth_data": {"format": "string", "data": 34},
+                        "serial_number": "INTCJ123-4567-890",
+                        "registration_number": "FA12345897",
+                    },
+                }
+            ]
+        }
+        response = self.client.put(
+            self.api_url, content_type="application/json", data=json.dumps(payload)
+        )
+        response_json = {"message": "Telemetry data successfully submitted"}
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.json(), response_json)
+
+    def test_invalid_current_states_payload(self):
+        payload = {
+            "observations": [
+                {
+                    "current_states": [{}],
+                    "flight_details": {
+                        "rid_details": {
+                            "id": "a3423b-213401-0023",
+                            "operator_id": "N.OP123456",
+                            "operation_description": "SafeFlightDrone company doing survey with DJI Inspire 2. See my privacy policy www.example.com/privacy.",
+                        },
+                        "eu_classification": {
+                            "category": "EUCategoryUndefined",
+                            "class": "EUClassUndefined",
+                        },
+                        "uas_id": {
+                            "serial_number": "INTCJ123-4567-890",
+                            "registration_id": "N.123456",
+                            "utm_id": "ae1fa066-6d68-4018-8274-af867966978e",
+                            "specific_session_id": "02-a1b2c3d4e5f60708",
+                        },
+                        "operator_location": {
+                            "position": {
+                                "lng": -118.456,
+                                "lat": 34.12,
+                                "accuracy_h": "HAUnknown",
+                                "accuracy_v": "VAUnknown",
+                            },
+                            "altitude": 19.5,
+                            "altitude_type": "Takeoff",
+                        },
+                        "auth_data": {"format": "string", "data": 34},
+                        "serial_number": "INTCJ123-4567-890",
+                        "registration_number": "FA12345897",
+                    },
+                }
+            ]
+        }
+        response = self.client.put(
+            self.api_url, content_type="application/json", data=json.dumps(payload)
+        )
+        response_json = {
+            "observations": [
+                {
+                    "current_states": [
+                        {
+                            "timestamp": ["This field is required."],
+                            "timestamp_accuracy": ["This field is required."],
+                            "operational_status": ["This field is required."],
+                            "position": ["This field is required."],
+                            "track": ["This field is required."],
+                            "speed": ["This field is required."],
+                            "speed_accuracy": ["This field is required."],
+                            "vertical_speed": ["This field is required."],
+                            "height": ["This field is required."],
+                        }
+                    ]
+                }
+            ]
+        }
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json(), response_json)
+
+    def test_invalid_flight_details_payload(self):
+        payload = {
+            "observations": [
+                {
+                    "current_states": [
+                        {
+                            "timestamp": {
+                                "value": "1985-04-12T23:20:50.52Z",
+                                "format": "RFC3339",
+                            },
+                            "timestamp_accuracy": 0,
+                            "operational_status": "Undeclared",
+                            "position": {
+                                "lat": 34.12,
+                                "lng": -118.456,
+                                "alt": 1321.2,
+                                "accuracy_h": "HAUnknown",
+                                "accuracy_v": "VAUnknown",
+                                "extrapolated": True,
+                                "pressure_altitude": 0,
+                            },
+                            "track": 0,
+                            "speed": 1.9,
+                            "speed_accuracy": "SAUnknown",
+                            "vertical_speed": 0.2,
+                            "height": {"distance": 0, "reference": "TakeoffLocation"},
+                            "group_radius": 0,
+                            "group_ceiling": 0,
+                            "group_floor": 0,
+                            "group_count": 1,
+                            "group_time_start": "2019-08-24T14:15:22Z",
+                            "group_time_end": "2019-08-24T14:15:22Z",
+                        }
+                    ],
+                    "flight_details": {},
+                }
+            ]
+        }
+        response = self.client.put(
+            self.api_url, content_type="application/json", data=json.dumps(payload)
+        )
+        response_json = {
+            "observations": [
+                {
+                    "flight_details": {
+                        "rid_details": ["This field is required."],
+                        "eu_classification": ["This field is required."],
+                        "uas_id": ["This field is required."],
+                        "operator_location": ["This field is required."],
+                        "auth_data": ["This field is required."],
+                        "serial_number": ["This field is required."],
+                        "registration_number": ["This field is required."],
+                    }
+                }
+            ]
+        }
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json(), response_json)

--- a/flight_feed_operations/urls.py
+++ b/flight_feed_operations/urls.py
@@ -5,7 +5,7 @@ urlpatterns = [
     path('set_air_traffic', flight_feed_views.set_air_traffic),
     path('get_air_traffic', flight_feed_views.get_air_traffic),
     path('start_opensky_feed', flight_feed_views.start_opensky_feed),
-    path('set_telemetry', flight_feed_views.set_telemetry),
+    path('set_telemetry', flight_feed_views.set_telemetry,name="set_telemetry"),
     path('set_signed_telemetry', flight_feed_views.set_signed_telemetry),    
     path('public_keys/', flight_feed_views.SignedTelmetryPublicKeyList.as_view()),
     path('public_keys/<uuid:pk>/', flight_feed_views.SignedTelmetryPublicKeyDetail.as_view()),

--- a/flight_feed_operations/views.py
+++ b/flight_feed_operations/views.py
@@ -13,15 +13,20 @@ from rest_framework.decorators import api_view
 from auth_helper.utils import requires_scopes
 from rid_operations import view_port_ops
 from rid_operations.data_definitions import (
-    RIDAircraftState, RIDFlightDetails, SignedUnSignedTelemetryObservations)
+    RIDAircraftState,
+    RIDFlightDetails,
+    SignedUnSignedTelemetryObservations,
+)
 from rid_operations.tasks import stream_rid_data_v22
 
 from . import flight_stream_helper
-from .data_definitions import (FlightObservationsProcessingResponse,
-                               SingleAirtrafficObservation)
+from .data_definitions import (
+    FlightObservationsProcessingResponse,
+    SingleAirtrafficObservation,
+)
 from .tasks import start_openskies_stream, write_incoming_air_traffic_data
 
-logger = logging.getLogger('django')
+logger = logging.getLogger("django")
 from os import environ as env
 
 from django.http import HttpRequest, HttpResponse
@@ -36,25 +41,33 @@ from encoders import DateTimeEncoder
 from .data_definitions import MessageVerificationFailedResponse
 from .models import SignedTelmetryPublicKey
 from .pki_helper import MessageVerifier, ResponseSigningOperations
-from .rid_telemetry_helper import (BlenderTelemetryValidator, NestedDict,
-                                   current_state_json_to_object,
-                                   flight_detail_json_to_object)
-from .serializers import (SignedTelmetryPublicKeySerializer, TelemetryRequest,
-                          TelemetryRequestSerializer)
+from .rid_telemetry_helper import (
+    BlenderTelemetryValidator,
+    NestedDict,
+    current_state_json_to_object,
+    flight_detail_json_to_object,
+)
+from .serializers import (
+    SignedTelmetryPublicKeySerializer,
+    TelemetryRequest,
+    TelemetryRequestSerializer,
+)
 
 ENV_FILE = find_dotenv()
 if ENV_FILE:
     load_dotenv(ENV_FILE)
 
-class HomeView(TemplateView):
-    template_name = 'homebase/home.html'
 
-@api_view(['GET'])
+class HomeView(TemplateView):
+    template_name = "homebase/home.html"
+
+
+@api_view(["GET"])
 def public_key_view(request):
     # Source: https://github.com/jazzband/django-oauth-toolkit/blob/016c6c3bf62c282991c2ce3164e8233b81e3dd4d/oauth2_provider/views/oidc.py#L105
     keys = []
-    private_key = env.get('SECRET_KEY', None)
-    
+    private_key = env.get("SECRET_KEY", None)
+
     if private_key:
         try:
             for pem in [private_key]:
@@ -65,82 +78,102 @@ def public_key_view(request):
 
             response = JsonResponse({"keys": keys})
             response["Access-Control-Allow-Origin"] = "*"
-        except: 
+        except:
             response = JsonResponse({})
     else:
         response = JsonResponse({})
-        
+
     return response
 
-    
 
-@api_view(['GET'])
+@api_view(["GET"])
 def ping(request):
-    return JsonResponse({"message":"pong"}, status=200)
+    return JsonResponse({"message": "pong"}, status=200)
 
-@api_view(['POST'])
-@requires_scopes(['blender.write'])
+
+@api_view(["POST"])
+@requires_scopes(["blender.write"])
 def set_air_traffic(request):
-
-    ''' This is the main POST method that takes in a request for Air traffic observation and processes the input data '''  
+    """This is the main POST method that takes in a request for Air traffic observation and processes the input data"""
 
     try:
-        assert request.headers['Content-Type'] == 'application/json'   
-    except AssertionError:     
-        msg = {"message":"Unsupported Media Type"}
+        assert request.headers["Content-Type"] == "application/json"
+    except AssertionError:
+        msg = {"message": "Unsupported Media Type"}
         return JsonResponse(msg, status=415)
-    else:    
+    else:
         req = request.data
-    
+
     try:
-        observations = req['observations']
+        observations = req["observations"]
     except KeyError as ke:
-        
-        msg = FlightObservationsProcessingResponse(message="At least one observation is required: observations with a list of observation objects. One or more of these were not found in your JSON request. For sample data see: https://github.com/openskies-sh/airtraffic-data-protocol-development/blob/master/Airtraffic-Data-Protocol.md#sample-traffic-object", status= 400)
+        msg = FlightObservationsProcessingResponse(
+            message="At least one observation is required: observations with a list of observation objects. One or more of these were not found in your JSON request. For sample data see: https://github.com/openskies-sh/airtraffic-data-protocol-development/blob/master/Airtraffic-Data-Protocol.md#sample-traffic-object",
+            status=400,
+        )
 
         m = asdict(msg)
-        return JsonResponse(m, status= m['status'])
+        return JsonResponse(m, status=m["status"])
 
-    for observation in observations:  
-        try: 
-            lat_dd = observation['lat_dd']
-            lon_dd = observation['lon_dd']
-            altitude_mm = observation['altitude_mm']
-            traffic_source = observation['traffic_source']
-            source_type = observation['source_type']
-            icao_address = observation['icao_address']
-            
+    for observation in observations:
+        try:
+            lat_dd = observation["lat_dd"]
+            lon_dd = observation["lon_dd"]
+            altitude_mm = observation["altitude_mm"]
+            traffic_source = observation["traffic_source"]
+            source_type = observation["source_type"]
+            icao_address = observation["icao_address"]
+
         except KeyError as obs_ke:
-            msg = {"message":"One of your obervations do not have the mandatory required field"}
+            msg = {
+                "message": "One of your obervations do not have the mandatory required field"
+            }
             return JsonResponse(msg, status=400)
             # logging.error("Not all data was provided")
         metadata = {}
 
-        if 'metadata' in observation.keys():
-            metadata = observation['metadata']
-            
-        so = SingleAirtrafficObservation(lat_dd= lat_dd, lon_dd=lon_dd, altitude_mm=altitude_mm, traffic_source= traffic_source, source_type= source_type, icao_address=icao_address, metadata= json.dumps(metadata))
-        
-        msgid = write_incoming_air_traffic_data.delay(json.dumps(asdict(so)))  # Send a job to the task queue
-       
-    op = FlightObservationsProcessingResponse(message="OK", status = 200)
+        if "metadata" in observation.keys():
+            metadata = observation["metadata"]
+
+        so = SingleAirtrafficObservation(
+            lat_dd=lat_dd,
+            lon_dd=lon_dd,
+            altitude_mm=altitude_mm,
+            traffic_source=traffic_source,
+            source_type=source_type,
+            icao_address=icao_address,
+            metadata=json.dumps(metadata),
+        )
+
+        msgid = write_incoming_air_traffic_data.delay(
+            json.dumps(asdict(so))
+        )  # Send a job to the task queue
+
+    op = FlightObservationsProcessingResponse(message="OK", status=200)
     return JsonResponse(asdict(op), status=op.status)
 
-@api_view(['GET'])
-@requires_scopes(['blender.read'])
+
+@api_view(["GET"])
+@requires_scopes(["blender.read"])
 def get_air_traffic(request):
-    ''' This is the end point for the rid_qualifier test DSS network call once a subscription is updated '''
+    """This is the end point for the rid_qualifier test DSS network call once a subscription is updated"""
 
     # get the view bounding box
     # get the existing subscription id , if no subscription exists, then reject
-    
+
     try:
-        view = request.query_params['view']
+        view = request.query_params["view"]
         view_port = [float(i) for i in view.split(",")]
     except Exception as ke:
-        incorrect_parameters = {"message": "A view bbox is necessary with four values: minx, miny, maxx and maxy"}
-        return JsonResponse(json.loads(json.dumps(incorrect_parameters)), status=400, content_type='application/json')
-    
+        incorrect_parameters = {
+            "message": "A view bbox is necessary with four values: minx, miny, maxx and maxy"
+        }
+        return JsonResponse(
+            json.loads(json.dumps(incorrect_parameters)),
+            status=400,
+            content_type="application/json",
+        )
+
     view_port_valid = view_port_ops.check_view_port(view_port_coords=view_port)
 
     b = shapely.geometry.box(view_port[1], view_port[0], view_port[3], view_port[2])
@@ -159,122 +192,210 @@ def get_air_traffic(request):
         stream_ops = flight_stream_helper.StreamHelperOps()
         pull_cg = stream_ops.get_pull_cg()
         all_streams_messages = pull_cg.read()
-        
+
         unique_flights = []
         # Keep only the latest message
         try:
-            for message in all_streams_messages:                     
-                unique_flights.append({'timestamp': message.timestamp,'seq': message.sequence, 'msg_data':message.data, 'address':message.data['icao_address']})            
+            for message in all_streams_messages:
+                unique_flights.append(
+                    {
+                        "timestamp": message.timestamp,
+                        "seq": message.sequence,
+                        "msg_data": message.data,
+                        "address": message.data["icao_address"],
+                    }
+                )
             # sort by date
-            unique_flights.sort(key=lambda item:item['timestamp'], reverse=True)
+            unique_flights.sort(key=lambda item: item["timestamp"], reverse=True)
             # Keep only the latest message
-            distinct_messages = {i['address']:i for i in reversed(unique_flights)}.values()
-            
-        except KeyError as ke: 
-            logger.error("Error in sorting distinct messages, ICAO name not defined %s" % ke)                     
+            distinct_messages = {
+                i["address"]: i for i in reversed(unique_flights)
+            }.values()
+
+        except KeyError as ke:
+            logger.error(
+                "Error in sorting distinct messages, ICAO name not defined %s" % ke
+            )
             distinct_messages = []
         all_traffic_observations: List[SingleAirtrafficObservation] = []
-        for observation in distinct_messages:     
-            observation_data = observation['msg_data']  
-            observation_metadata = json.loads(observation_data['metadata'])            
-            so = SingleAirtrafficObservation(lat_dd=observation_data['lat_dd'], lon_dd=observation_data['lon_dd'], altitude_mm=observation_data['altitude_mm'],traffic_source=observation_data['traffic_source'], source_type = observation_data['source_type'], icao_address=observation_data['icao_address'], metadata=observation_metadata)
+        for observation in distinct_messages:
+            observation_data = observation["msg_data"]
+            observation_metadata = json.loads(observation_data["metadata"])
+            so = SingleAirtrafficObservation(
+                lat_dd=observation_data["lat_dd"],
+                lon_dd=observation_data["lon_dd"],
+                altitude_mm=observation_data["altitude_mm"],
+                traffic_source=observation_data["traffic_source"],
+                source_type=observation_data["source_type"],
+                icao_address=observation_data["icao_address"],
+                metadata=observation_metadata,
+            )
             all_traffic_observations.append(asdict(so))
-        
-        return JsonResponse({"observations":all_traffic_observations},  status=200, content_type='application/json')
+
+        return JsonResponse(
+            {"observations": all_traffic_observations},
+            status=200,
+            content_type="application/json",
+        )
     else:
         view_port_error = {"message": "A incorrect view port bbox was provided"}
-        return JsonResponse(json.loads(json.dumps(view_port_error)), status=400, content_type='application/json')
+        return JsonResponse(
+            json.loads(json.dumps(view_port_error)),
+            status=400,
+            content_type="application/json",
+        )
 
 
-@api_view(['GET'])
-@requires_scopes(['blender.read'])
+@api_view(["GET"])
+@requires_scopes(["blender.read"])
 def start_opensky_feed(request):
-    # This method takes in a view port as a lat1,lon1,lat2,lon2 co-ordinate system and for 60 seconds starts the stream of data from the OpenSky Network. 
+    # This method takes in a view port as a lat1,lon1,lat2,lon2 co-ordinate system and for 60 seconds starts the stream of data from the OpenSky Network.
 
     try:
-        view = request.query_params['view']
+        view = request.query_params["view"]
         view_port = [float(i) for i in view.split(",")]
     except Exception as ke:
-        incorrect_parameters = {"message": "A view bbox is necessary with four values: minx, miny, maxx and maxy"}
-        
-        return JsonResponse(json.loads(json.dumps(incorrect_parameters)), status=400, content_type='application/json')
-    
+        incorrect_parameters = {
+            "message": "A view bbox is necessary with four values: minx, miny, maxx and maxy"
+        }
+
+        return JsonResponse(
+            json.loads(json.dumps(incorrect_parameters)),
+            status=400,
+            content_type="application/json",
+        )
+
     view_port_valid = view_port_ops.check_view_port(view_port_coords=view_port)
-    
+
     if view_port_valid:
-        start_openskies_stream.delay(view_port = json.dumps(view_port))
-        
-        return JsonResponse({"message":"Openskies Newtork stream started"},  status=200, content_type='application/json')
+        start_openskies_stream.delay(view_port=json.dumps(view_port))
+
+        return JsonResponse(
+            {"message": "Openskies Newtork stream started"},
+            status=200,
+            content_type="application/json",
+        )
     else:
         view_port_error = {"message": "An incorrect view port bbox was provided"}
-        
-        return JsonResponse(json.loads(json.dumps(view_port_error)), status=400, content_type='application/json')
 
-@api_view(['PUT'])
-def set_signed_telemetry(request):   
+        return JsonResponse(
+            json.loads(json.dumps(view_port_error)),
+            status=400,
+            content_type="application/json",
+        )
+
+
+@api_view(["PUT"])
+def set_signed_telemetry(request):
     # This endpoint sets signed telemetry details into Flight Blender, use this endpoint to securly send signed telemetry information into Blender, since the messages are signed, we turn off any auth requirements for tokens and validate against allowed public keys in Blender.
-    
+
     my_message_verifier = MessageVerifier()
     my_response_signer = ResponseSigningOperations()
     verified = my_message_verifier.verify_message(request)
-    
+
     if not verified:
-        message_verification_failed_response = MessageVerificationFailedResponse(message= "Could not verify against public keys setup in Flight Blender")
-        return JsonResponse(asdict(message_verification_failed_response), status=400, content_type='application/json')
+        message_verification_failed_response = MessageVerificationFailedResponse(
+            message="Could not verify against public keys setup in Flight Blender"
+        )
+        return JsonResponse(
+            asdict(message_verification_failed_response),
+            status=400,
+            content_type="application/json",
+        )
     else:
         raw_data = request.data
         my_telemetry_validator = BlenderTelemetryValidator()
-        observations_exist = my_telemetry_validator.validate_observation_key_exists(raw_request_data= raw_data)
+        observations_exist = my_telemetry_validator.validate_observation_key_exists(
+            raw_request_data=raw_data
+        )
         if not observations_exist:
-            incorrect_parameters = {"message": "A flight observation object with current state and flight details is necessary"}
-            return JsonResponse(incorrect_parameters, status=400, content_type='application/json')
+            incorrect_parameters = {
+                "message": "A flight observation object with current state and flight details is necessary"
+            }
+            return JsonResponse(
+                incorrect_parameters, status=400, content_type="application/json"
+            )
         # Get a list of flight data
 
         raw_data = request.data
 
         my_telemetry_validator = BlenderTelemetryValidator()
 
-        observations_exist = my_telemetry_validator.validate_observation_key_exists(raw_request_data= raw_data)
+        observations_exist = my_telemetry_validator.validate_observation_key_exists(
+            raw_request_data=raw_data
+        )
         if not observations_exist:
-            incorrect_parameters = {"message": "A flight observation object with current state and flight details is necessary"}
-            return JsonResponse(incorrect_parameters, status=400, content_type='application/json')
+            incorrect_parameters = {
+                "message": "A flight observation object with current state and flight details is necessary"
+            }
+            return JsonResponse(
+                incorrect_parameters, status=400, content_type="application/json"
+            )
         # Get a list of flight data
 
-        rid_observations = raw_data['observations']
-        
+        rid_observations = raw_data["observations"]
+
         unsigned_telemetry_observations: List[SignedUnSignedTelemetryObservations] = []
-        for flight in rid_observations: 
-            flight_details_current_states_exist = my_telemetry_validator.validate_flight_details_current_states_exist(flight= flight)
+        for flight in rid_observations:
+            flight_details_current_states_exist = (
+                my_telemetry_validator.validate_flight_details_current_states_exist(
+                    flight=flight
+                )
+            )
             if not flight_details_current_states_exist:
-                incorrect_parameters = {"message": "A flights object with current states, flight details is necessary"}
-                return JsonResponse(incorrect_parameters, status=400, content_type='application/json')                  
+                incorrect_parameters = {
+                    "message": "A flights object with current states, flight details is necessary"
+                }
+                return JsonResponse(
+                    incorrect_parameters, status=400, content_type="application/json"
+                )
 
-            current_states = flight['current_states']
-            flight_details = flight['flight_details']
+            current_states = flight["current_states"]
+            flight_details = flight["flight_details"]
             try:
-                all_states: List[RIDAircraftState] = my_telemetry_validator.parse_validate_current_states(current_states = current_states)
-                rid_flight_details = flight_details['rid_details']
-                f_details: RIDFlightDetails = my_telemetry_validator.parse_validate_rid_details(rid_flight_details = rid_flight_details)
-                    
-            except KeyError as ke: 
-                incorrect_parameters = {"message": "A states object with a fully valid current states is necessary, the parsing the following key encountered errors %s" % ke}
-                return JsonResponse(incorrect_parameters, status=400, content_type='application/json')        
+                all_states: List[
+                    RIDAircraftState
+                ] = my_telemetry_validator.parse_validate_current_states(
+                    current_states=current_states
+                )
+                rid_flight_details = flight_details["rid_details"]
+                f_details: RIDFlightDetails = (
+                    my_telemetry_validator.parse_validate_rid_details(
+                        rid_flight_details=rid_flight_details
+                    )
+                )
 
-            single_observation_set = SignedUnSignedTelemetryObservations(current_states = all_states, flight_details = f_details)
+            except KeyError as ke:
+                incorrect_parameters = {
+                    "message": "A states object with a fully valid current states is necessary, the parsing the following key encountered errors %s"
+                    % ke
+                }
+                return JsonResponse(
+                    incorrect_parameters, status=400, content_type="application/json"
+                )
 
-            unsigned_telemetry_observations.append(asdict(single_observation_set, dict_factory=NestedDict))
+            single_observation_set = SignedUnSignedTelemetryObservations(
+                current_states=all_states, flight_details=f_details
+            )
 
-            stream_rid_data_v22.delay(rid_telemetry_observations= json.dumps(unsigned_telemetry_observations))
+            unsigned_telemetry_observations.append(
+                asdict(single_observation_set, dict_factory=NestedDict)
+            )
+
+            stream_rid_data_v22.delay(
+                rid_telemetry_observations=json.dumps(unsigned_telemetry_observations)
+            )
         submission_success = {"message": "Telemetry data successfully submitted"}
-        content_digest = my_response_signer.generate_content_digest(submission_success)       
-        signed_data = my_response_signer.sign_json_via_django(submission_success)              
-        submission_success['signed'] = signed_data
-        response = JsonResponse(submission_success, status=201, content_type='application/json')
+        content_digest = my_response_signer.generate_content_digest(submission_success)
+        signed_data = my_response_signer.sign_json_via_django(submission_success)
+        submission_success["signed"] = signed_data
+        response = JsonResponse(
+            submission_success, status=201, content_type="application/json"
+        )
         response["Content-Digest"] = content_digest
-        response['req'] = request.headers['Signature']
-        
+        response["req"] = request.headers["Signature"]
+
         return response
-            
 
 
 def _parse_telemetry_request(json_payload):
@@ -290,39 +411,41 @@ def _parse_telemetry_request(json_payload):
 
     validated_data = serializer.validated_data
     telemetry_request = serializer.create(validated_data)
-    return telemetry_request,error
+    return telemetry_request, error
 
-def _get_flight_details_from_observation(observation:TelemetryRequest):
+
+def _get_flight_details_from_observation(observation: TelemetryRequest):
     flight_details = observation["flight_details"]
     flight_details_json_str = json.dumps(flight_details)
-    flight_details_json =json.loads(flight_details_json_str)
+    flight_details_json = json.loads(flight_details_json_str)
 
     parsed_flight_details = flight_detail_json_to_object(flight_details_json)
     return parsed_flight_details
 
-def _get_current_states_from_observation(observation:TelemetryRequest):
-    states =observation["current_states"]
-    states_json_str = json.dumps(states,cls=DateTimeEncoder)
-    states_json =json.loads(states_json_str)
-    current_states:List[RIDAircraftState] = []
+
+def _get_current_states_from_observation(observation: TelemetryRequest):
+    states = observation["current_states"]
+    states_json_str = json.dumps(states, cls=DateTimeEncoder)
+    states_json = json.loads(states_json_str)
+    current_states: List[RIDAircraftState] = []
     for state_json in states_json:
-        current_state =current_state_json_to_object(state_json)
+        current_state = current_state_json_to_object(state_json)
         current_states.append(current_state)
     return current_states
 
 
-@api_view(['PUT'])
-@requires_scopes(['blender.write'])
-def set_telemetry(request:HttpRequest):
-    ''' 
+@api_view(["PUT"])
+@requires_scopes(["blender.write"])
+def set_telemetry(request: HttpRequest):
+    """
     A RIDOperatorDetails object is posted here
     This endpoints receives data from GCS and / or flights and processes remote ID data.
-    '''
-    # TODO: Use dacite to parse incoming json into a dataclass    
+    """
+    # TODO: Use dacite to parse incoming json into a dataclass
     stream = io.BytesIO(request.body)
     json_payload = JSONParser().parse(stream)
 
-    parsed_telemetry_request,parse_error=_parse_telemetry_request(json_payload)
+    parsed_telemetry_request, parse_error = _parse_telemetry_request(json_payload)
     if parse_error:
         return HttpResponse(
             json.dumps(parse_error),
@@ -333,72 +456,39 @@ def set_telemetry(request:HttpRequest):
     unsigned_telemetry_observations: List[SignedUnSignedTelemetryObservations] = []
     observations = parsed_telemetry_request.observations
     for observation in observations:
-
         flight_details = _get_flight_details_from_observation(observation)
-        current_states: List[RIDAircraftState] = _get_current_states_from_observation(observation)
+        current_states: List[RIDAircraftState] = _get_current_states_from_observation(
+            observation
+        )
 
-        single_observation_set = SignedUnSignedTelemetryObservations(current_states = current_states, flight_details = flight_details)
-        
-        unsigned_telemetry_observations.append(asdict(single_observation_set, dict_factory=NestedDict))
-        unsigned_telemetry_observations_str = json.dumps(unsigned_telemetry_observations)
-        stream_rid_data_v22.delay(rid_telemetry_observations= unsigned_telemetry_observations_str)
+        single_observation_set = SignedUnSignedTelemetryObservations(
+            current_states=current_states, flight_details=flight_details
+        )
+
+        unsigned_telemetry_observations.append(
+            asdict(single_observation_set, dict_factory=NestedDict)
+        )
+        unsigned_telemetry_observations_str = json.dumps(
+            unsigned_telemetry_observations
+        )
+        stream_rid_data_v22.delay(
+            rid_telemetry_observations=unsigned_telemetry_observations_str
+        )
     submission_success = {"message": "Telemetry data successfully submitted"}
-    return JsonResponse(submission_success, status=status.HTTP_201_CREATED, content_type='application/json')
+    return JsonResponse(
+        submission_success,
+        status=status.HTTP_201_CREATED,
+        content_type="application/json",
+    )
 
 
-#TODO: Delete this and use set_telemetry() instead
-# This endpoint should not be used. Use set_telemetry() instead
-@api_view(['PUT'])
-@requires_scopes(['blender.write'])
-def set_telemetry_old(request):
-    ''' A RIDOperatorDetails object is posted here'''
-    # This endpoints receives data from GCS and / or flights and processes remote ID data.    
-    raw_data = request.data
-
-    my_telemetry_validator = BlenderTelemetryValidator()
-
-    observations_exist = my_telemetry_validator.validate_observation_key_exists(raw_request_data= raw_data)
-    if not observations_exist:
-        incorrect_parameters = {"message": "A flight observation object with current state and flight details is necessary"}
-        return JsonResponse(incorrect_parameters, status=400, content_type='application/json')
-    # Get a list of flight data
-
-    rid_observations = raw_data['observations']
-    
-    unsigned_telemetry_observations: List[SignedUnSignedTelemetryObservations] = []
-    for flight in rid_observations: 
-        flight_details_current_states_exist = my_telemetry_validator.validate_flight_details_current_states_exist(flight= flight)
-        if not flight_details_current_states_exist:
-            incorrect_parameters = {"message": "A flights object with current states, flight details is necessary"}
-            return JsonResponse(incorrect_parameters, status=status.HTTP_400_BAD_REQUEST, content_type='application/json')                  
-
-        current_states = flight['current_states']
-        flight_details = flight['flight_details']
-        try:
-            all_states: List[RIDAircraftState] = my_telemetry_validator.parse_validate_current_states(current_states = current_states)
-            rid_flight_details = flight_details['rid_details']
-            f_details: RIDFlightDetails = my_telemetry_validator.parse_validate_rid_details(rid_flight_details = rid_flight_details)
-                
-        except KeyError as ke: 
-            incorrect_parameters = {"message": "A states object with a fully valid current states is necessary, the parsing the following key encountered errors %s" % ke}
-            return JsonResponse(incorrect_parameters, status=status.HTTP_400_BAD_REQUEST, content_type='application/json')        
-
-        single_observation_set = SignedUnSignedTelemetryObservations(current_states = all_states, flight_details = f_details)
-        print(single_observation_set)
-        unsigned_telemetry_observations.append(asdict(single_observation_set, dict_factory=NestedDict))
-        stream_rid_data_v22.delay(rid_telemetry_observations= json.dumps(unsigned_telemetry_observations))
-    submission_success = {"message": "Telemetry data succesfully submitted"}
-    return JsonResponse(submission_success, status=status.HTTP_201_CREATED, content_type='application/json')
-
-        
-        
-@method_decorator(requires_scopes(['geo-awareness.test']), name='dispatch')
+@method_decorator(requires_scopes(["geo-awareness.test"]), name="dispatch")
 class SignedTelmetryPublicKeyList(generics.ListCreateAPIView):
     queryset = SignedTelmetryPublicKey.objects.all()
     serializer_class = SignedTelmetryPublicKeySerializer
 
 
-@method_decorator(requires_scopes(['geo-awareness.test']), name='dispatch')
+@method_decorator(requires_scopes(["geo-awareness.test"]), name="dispatch")
 class SignedTelmetryPublicKeyDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = SignedTelmetryPublicKey.objects.all()
     serializer_class = SignedTelmetryPublicKeySerializer

--- a/flight_feed_operations/views.py
+++ b/flight_feed_operations/views.py
@@ -22,7 +22,7 @@ from .rid_telemetry_helper import BlenderTelemetryValidator, NestedDict
 from django.utils.decorators import method_decorator
 from .models import SignedTelmetryPublicKey
 from .serializers import SignedTelmetryPublicKeySerializer
-from rest_framework import generics
+from rest_framework import generics,status
 from jwcrypto import jwk, jwt
 from os import environ as env
 from dotenv import load_dotenv, find_dotenv
@@ -283,7 +283,7 @@ def set_telemetry(request):
         flight_details_current_states_exist = my_telemetry_validator.validate_flight_details_current_states_exist(flight= flight)
         if not flight_details_current_states_exist:
             incorrect_parameters = {"message": "A flights object with current states, flight details is necessary"}
-            return JsonResponse(incorrect_parameters, status=400, content_type='application/json')                  
+            return JsonResponse(incorrect_parameters, status=status.HTTP_400_BAD_REQUEST, content_type='application/json')                  
 
         current_states = flight['current_states']
         flight_details = flight['flight_details']
@@ -294,7 +294,7 @@ def set_telemetry(request):
                 
         except KeyError as ke: 
             incorrect_parameters = {"message": "A states object with a fully valid current states is necessary, the parsing the following key encountered errors %s" % ke}
-            return JsonResponse(incorrect_parameters, status=400, content_type='application/json')        
+            return JsonResponse(incorrect_parameters, status=status.HTTP_400_BAD_REQUEST, content_type='application/json')        
 
         single_observation_set = SignedUnSignedTelemetryObservations(current_states = all_states, flight_details = f_details)
 
@@ -302,7 +302,7 @@ def set_telemetry(request):
 
         stream_rid_data_v22.delay(rid_telemetry_observations= json.dumps(unsigned_telemetry_observations))
     submission_success = {"message": "Telemetry data succesfully submitted"}
-    return JsonResponse(submission_success, status=201, content_type='application/json')
+    return JsonResponse(submission_success, status=status.HTTP_201_CREATED, content_type='application/json')
 
         
         

--- a/flight_feed_operations/views.py
+++ b/flight_feed_operations/views.py
@@ -314,6 +314,11 @@ def _get_current_states_from_observation(observation:TelemetryRequest):
 @api_view(['PUT'])
 @requires_scopes(['blender.write'])
 def set_telemetry(request:HttpRequest):
+    ''' 
+    A RIDOperatorDetails object is posted here
+    This endpoints receives data from GCS and / or flights and processes remote ID data.
+    '''
+    # TODO: Use dacite to parse incoming json into a dataclass    
     stream = io.BytesIO(request.body)
     json_payload = JSONParser().parse(stream)
 
@@ -347,8 +352,7 @@ def set_telemetry(request:HttpRequest):
 @requires_scopes(['blender.write'])
 def set_telemetry_old(request):
     ''' A RIDOperatorDetails object is posted here'''
-    # This endpoints receives data from GCS and / or flights and processes remote ID data. 
-    # TODO: Use dacite to parse incoming json into a dataclass    
+    # This endpoints receives data from GCS and / or flights and processes remote ID data.    
     raw_data = request.data
 
     my_telemetry_validator = BlenderTelemetryValidator()


### PR DESCRIPTION
## Proposed changes

[JIRA](https://ssrc.atlassian.net/browse/SCUTM-344)

Removed the old implementation of `set_telemetry()` and introduced a new `set_telemetry()` with below changes:

- Removed hardcoded HTTP status codes
- Introduced Serialiser code base to verify the payload and minimise the use of **BlenderTelemetryValidator** class
- Use existing dataclasses to construct the objects from dictionaries
- Improved the code flow by re-arranging the logic flow
- Added unit tests for `PUT /flight_stream/set_telemetry` endpoint

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with the changes
- [x] Added new tests that prove the changes in this PR works
- [ ] Added necessary documentation (if appropriate)
- [ ] Added copyrights to new files (if appropriate)

## Further comments

Removed the OLD implementation of set_telemetry() and replaced it with the new function.
The authorization for endpoints during unit testing is still done via the hardcoded JWT. This will be changed in the upcoming PRs.