### PR TITLE
adjust docker compose file so that we can choose which docker compose…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,18 @@
+# Define the Docker Compose command based on user input
+DOCKER_COMPOSE_CMD ?= docker-compose
+
 # Building commands
 build:
-	docker-compose build
+	$(DOCKER_COMPOSE_CMD) build
 
 rebuild:
-	docker-compose build --no-cache
+	$(DOCKER_COMPOSE_CMD) build --no-cache
 
 up:
-	docker-compose up -d
+	$(DOCKER_COMPOSE_CMD) up -d
+
 down:
-	docker-compose down
+	$(DOCKER_COMPOSE_CMD) down
 
 # Linting commands
 lint:
@@ -22,7 +26,7 @@ cleanimports:
 
 # Run tests
 testprep:
-	docker exec -it flight-blender-web-1 python -m pip install --upgrade -r requirements_dev.txt
+	$(DOCKER_COMPOSE_CMD) exec -it flight-blender-web-1 python -m pip install --upgrade -r requirements_dev.txt
 
 test: testprep
-	docker exec -it flight-blender-web-1 pytest
+	$(DOCKER_COMPOSE_CMD) exec -it flight-blender-web-1 pytest

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ cleanimports:
 
 # Run tests
 testprep:
-	$(DOCKER_COMPOSE_CMD) exec -it flight-blender-web-1 python -m pip install --upgrade -r requirements_dev.txt
+	docker exec -it flight-blender-web-1 python -m pip install --upgrade -r requirements_dev.txt
 
 test: testprep
-	$(DOCKER_COMPOSE_CMD) exec -it flight-blender-web-1 pytest
+	docker exec -it flight-blender-web-1 pytest


### PR DESCRIPTION
New versions of docker include "compose" as a tool, meaning that you do not have to install docker-compose separately anymore.

I have made adjustments to the flight-blender makefile so that you can set which method to use via environment variables.

# Use docker-compose
DOCKER_COMPOSE_CMD=docker-compose make build

# Use docker compose
DOCKER_COMPOSE_CMD="docker compose" make build

# Setting the DOCKER_COMPOSE_CMD as an environment variable
1. Open ~/.profile in a text editor
2. Add the following line at the bottom of the file (if you have the newest version of docker):
  ```export DOCKER_COMPOSE_CMD="docker compose"```
3. Run the following command:
  ```source ~/.profile```
4. Navigate to the flight-blender root folder and run:
  ```make build```
  
 You should see the build running with "docker compose" as apposed to "docker-compose"