### PR TITLE
Added unit tests for Notification module

### DIFF
--- a/notification_operations/notification_helper.py
+++ b/notification_operations/notification_helper.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from dataclasses import asdict
 
 import pika
 from dotenv import find_dotenv, load_dotenv
@@ -76,3 +75,4 @@ class InitialNotificationFactory:
     def close(self):
         self.channel.close()
         self.connection.close()
+        logger.info(f"Trying to close connection...")

--- a/notification_operations/test_notification.py
+++ b/notification_operations/test_notification.py
@@ -1,0 +1,119 @@
+import os
+from os import environ as env
+from unittest.mock import MagicMock, call, patch
+
+from django.test import TestCase
+
+from notification_operations import notification
+from notification_operations.data_definitions import NotificationLevel
+from notification_operations.notification_helper import InitialNotificationFactory
+
+
+class NotificationSendingTests(TestCase):
+    @patch("notification_operations.notification.logger", autospec=True)
+    @patch.dict(os.environ, {"AMQP_URL": ""})
+    def test_no_amqp_url(self, mock_notification_logger):
+        mock_notification_logger.info = MagicMock()
+        notification.send_operational_update_message(
+            flight_declaration_id="0001",
+            message_text="Test Message",
+            level=NotificationLevel.INFO,
+        )
+        mock_notification_logger.info.assert_called_once_with("No AMQP URL specified")
+
+    @patch("notification_operations.notification.logger", autospec=True)
+    def test_notification_without_timestamp_without_logger_message(
+        self, mock_notification_logger
+    ):
+        mock_notification_logger.info = MagicMock()
+        notification.send_operational_update_message(
+            flight_declaration_id="0001",
+            message_text="Test Message",
+            level=NotificationLevel.INFO,
+        )
+        mock_notification_logger.info.assert_called_once_with("No log message provided")
+
+    @patch("notification_operations.notification.logger", autospec=True)
+    def test_notification_without_timestamp_with_logger_message(
+        self, mock_notification_logger
+    ):
+        mock_notification_logger.info = MagicMock()
+        notification.send_operational_update_message(
+            flight_declaration_id="0001",
+            message_text="Test Message",
+            level=NotificationLevel.ERROR,
+            log_message="This is a test log message",
+        )
+        mock_notification_logger.info.assert_called_once_with(
+            "This is a test log message"
+        )
+
+    @patch("notification_operations.notification.logger", autospec=True)
+    def test_notification_without_timestamp(self, mock_notification_logger):
+        mock_notification_logger.info = MagicMock()
+        notification.send_operational_update_message(
+            flight_declaration_id="0001",
+            message_text="Test Message",
+            level=NotificationLevel.ERROR,
+            timestamp="Test time string",
+            log_message="This is a test log message",
+        )
+        mock_notification_logger.info.assert_called_once_with(
+            "This is a test log message"
+        )
+
+    @patch("notification_operations.notification.logger", autospec=True)
+    @patch("notification_operations.notification_helper.logger", autospec=True)
+    def test_notification_with_all_logs(
+        self, mock_notification_helper_logger, mock_notification_logger
+    ):
+        mock_notification_logger.info = MagicMock()
+        mock_notification_helper_logger.info = MagicMock()
+        notification.send_operational_update_message(
+            flight_declaration_id="0001",
+            message_text="Test Message",
+            level=NotificationLevel.CRITICAL,
+            timestamp="Test time string",
+            log_message="This is a test log message",
+        )
+
+        # Logs from notification_helper
+        mock_notification_helper_logger.info.assert_has_calls(
+            calls=[
+                call("Trying to declare queue (0001)..."),
+                call(
+                    "Trying to bind queue (operational_events) with routing key (0001)..."
+                ),
+                call(
+                    'Sent message. Exchange: operational_events, Routing Key: 0001, Body: {"body": "Test Message", "level": "critical", "timestamp": "Test time string"}'
+                ),
+            ],
+            any_order=False,
+        )
+        # Logs from notification
+
+        mock_notification_logger.info.assert_called_once_with(
+            "This is a test log message"
+        )
+
+
+class NotificationExchangeInitialTests(TestCase):
+    def setUp(self):
+        _amqp_connection_url = env.get("AMQP_URL", 0)
+        self.notification_declaration = InitialNotificationFactory(
+            amqp_connection_url=_amqp_connection_url,
+            exchange_name="operational_events",
+        )
+
+    @patch("notification_operations.notification_helper.logger", autospec=True)
+    def test_declare_exchange(self, mock_notification_helper_logger):
+        mock_notification_helper_logger.info = MagicMock()
+        self.notification_declaration.declare_exchange()
+        self.notification_declaration.close()
+        mock_notification_helper_logger.info.assert_has_calls(
+            calls=[
+                call("Trying to declare exchange (operational_events)..."),
+                call("Trying to close connection..."),
+            ],
+            any_order=False,
+        )


### PR DESCRIPTION
## Proposed changes

[JIRA](https://ssrc.atlassian.net/browse/SCUTM-427)

In previous [PR](https://github.com/tiiuae/flight-blender/pull/46), I removed a redundant function definition `send_operational_update_message()` form sub modules and implemented this function in a reusable notification module.

This PR adds the unit tests to this module
## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with the changes
- [x] Added new tests that prove the changes in this PR works
- [ ] Added necessary documentation (if appropriate)
- [ ] Added copyrights to new files (if appropriate)

## Further comments

_Add special comments about the changes here if required._