### PR TITLE
Fixed deprecations found in the repo

### DIFF
--- a/auth_helper/common.py
+++ b/auth_helper/common.py
@@ -14,9 +14,9 @@ def get_redis():
     redis_password = env.get('REDIS_PASSWORD', None)
     
     if redis_password:
-        r = redis.Redis(host=redis_host, port=redis_port, password = redis_password, charset="utf-8",decode_responses=True)
+        r = redis.Redis(host=redis_host, port=redis_port, password = redis_password, encoding="utf-8",decode_responses=True)
     else:
-        r = redis.Redis(host=redis_host, port=redis_port, charset="utf-8",decode_responses=True)
+        r = redis.Redis(host=redis_host, port=redis_port, encoding="utf-8",decode_responses=True)
 
     return r
 

--- a/flight_declaration_operations/test_views.py
+++ b/flight_declaration_operations/test_views.py
@@ -600,6 +600,6 @@ class FlightDeclarationGetTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["total"], 3)
 
-        self.assertEquals(response.json()["results"][0]["aircraft_id"], "334455")
-        self.assertEquals(response.json()["results"][1]["aircraft_id"], "000")
-        self.assertEquals(response.json()["results"][2]["aircraft_id"], "112233")
+        self.assertEqual(response.json()["results"][0]["aircraft_id"], "334455")
+        self.assertEqual(response.json()["results"][1]["aircraft_id"], "000")
+        self.assertEqual(response.json()["results"][2]["aircraft_id"], "112233")

--- a/importers/common.py
+++ b/importers/common.py
@@ -14,9 +14,9 @@ def get_redis():
     redis_password = env.get('REDIS_PASSWORD', None)
     
     if redis_password:
-        r = redis.Redis(host=redis_host, port=redis_port, password = redis_password, charset="utf-8",decode_responses=True)
+        r = redis.Redis(host=redis_host, port=redis_port, password = redis_password, encoding="utf-8",decode_responses=True)
     else:
-        r = redis.Redis(host=redis_host, port=redis_port, charset="utf-8",decode_responses=True)
+        r = redis.Redis(host=redis_host, port=redis_port, encoding="utf-8",decode_responses=True)
 
     return r
 


### PR DESCRIPTION
## Proposed changes

There were some deprecation warnings shown in the repo. Fixed them.

- `AssertEquals()` has been deprecated in Unit tests libraries. Hence using `AsserEqual()` instead.
- `charset` argument has been changed to `encoding` in `Redis` instance.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with the changes
- [ ] Added new tests that prove the changes in this PR works
- [ ] Added necessary documentation (if appropriate)
- [ ] Added copyrights to new files (if appropriate)

## Further comments

_Add special comments about the changes here if required._