### PR TITLE
Removed NotificationMessage enum from Celery payload and use it as a String

### DIFF
--- a/flight_declaration_operations/tasks.py
+++ b/flight_declaration_operations/tasks.py
@@ -23,7 +23,7 @@ load_dotenv(find_dotenv())
 def _send_flight_approved_message(
     flight_declaration_id: str,
     message_text: str,
-    level: str = NotificationLevel.INFO,
+    level: str = NotificationLevel.INFO.value,
     timestamp: str = None,
 ):
     amqp_connection_url = env.get("AMQP_URL", 0)
@@ -63,7 +63,7 @@ def submit_flight_declaration_to_dss(flight_declaration_id: str):
         _send_flight_approved_message.delay(
             flight_declaration_id=flight_declaration_id,
             message_text=message,
-            level=NotificationLevel.INFO,
+            level=NotificationLevel.INFO.value,
         )
         fo.save()
         return
@@ -85,7 +85,7 @@ def submit_flight_declaration_to_dss(flight_declaration_id: str):
         notification.send_operational_update_message.delay(
             flight_declaration_id=flight_declaration_id,
             message_text=validation_not_ok_msg,
-            level=NotificationLevel.ERROR,
+            level=NotificationLevel.ERROR.value,
             log_message="Submitted Flight Declaration Notification",
         )
         return
@@ -96,7 +96,7 @@ def submit_flight_declaration_to_dss(flight_declaration_id: str):
     notification.send_operational_update_message.delay(
         flight_declaration_id=flight_declaration_id,
         message_text=validation_ok_msg,
-        level=NotificationLevel.INFO,
+        level=NotificationLevel.INFO.value,
         log_message="Submitted Flight Declaration Notification",
     )
 
@@ -117,7 +117,7 @@ def submit_flight_declaration_to_dss(flight_declaration_id: str):
         notification.send_operational_update_message.delay(
             flight_declaration_id=flight_declaration_id,
             message_text=dss_submission_error_msg,
-            level=NotificationLevel.ERROR,
+            level=NotificationLevel.ERROR.value,
             log_message="Submitted Flight Declaration Notification",
         )
         return
@@ -133,7 +133,7 @@ def submit_flight_declaration_to_dss(flight_declaration_id: str):
     notification.send_operational_update_message.delay(
         flight_declaration_id=flight_declaration_id,
         message_text=submission_success_msg,
-        level=NotificationLevel.INFO,
+        level=NotificationLevel.INFO.value,
         log_message="Submitted Flight Declaration Notification",
     )
 
@@ -147,7 +147,7 @@ def submit_flight_declaration_to_dss(flight_declaration_id: str):
     notification.send_operational_update_message.delay(
         flight_declaration_id=flight_declaration_id,
         message_text=submission_state_updated_msg,
-        level=NotificationLevel.INFO,
+        level=NotificationLevel.INFO.value,
         log_message="Submitted Flight Declaration Notification",
     )
     fo.save()

--- a/notification_operations/data_definitions.py
+++ b/notification_operations/data_definitions.py
@@ -15,13 +15,13 @@ class NotificationMessage:
     """This object will hold messages that will go to the operational Notifications"""
 
     body: str
-    level: NotificationLevel
+    level: str
     timestamp: str
     
     def to_dict(self):
-        # Convert the Enum to its string representation
+        # Convert the obj to its string representation
         return {
             "body": self.body,
-            "level": self.level.value,
+            "level": self.level,
             "timestamp": self.timestamp,
         }

--- a/notification_operations/notification.py
+++ b/notification_operations/notification.py
@@ -6,7 +6,7 @@ from dotenv import find_dotenv, load_dotenv
 
 from flight_blender.celery import app
 
-from .data_definitions import NotificationLevel, NotificationMessage
+from .data_definitions import NotificationMessage
 from .notification_helper import NotificationFactory
 
 logger = logging.getLogger("django")
@@ -17,7 +17,7 @@ load_dotenv(find_dotenv())
 def send_operational_update_message(
     flight_declaration_id: str,
     message_text: str,
-    level: NotificationLevel = NotificationLevel.INFO,
+    level:str,
     timestamp: str = None,
     log_message: str = "No log message provided",
 ):

--- a/notification_operations/notification_helper.py
+++ b/notification_operations/notification_helper.py
@@ -24,7 +24,7 @@ class NotificationFactory:
         self.flight_declaration_id = flight_declaration_id
 
     def send_message(self, message_details: NotificationMessage):
-        msg_details = json.dumps((message_details.to_dict()))
+        msg_details = json.dumps(message_details.to_dict())
         self.channel.basic_publish(
             exchange=self.exchange,
             routing_key=self.flight_declaration_id,

--- a/notification_operations/test_notification.py
+++ b/notification_operations/test_notification.py
@@ -17,7 +17,7 @@ class NotificationSendingTests(TestCase):
         notification.send_operational_update_message(
             flight_declaration_id="0001",
             message_text="Test Message",
-            level=NotificationLevel.INFO,
+            level=NotificationLevel.INFO.value,
         )
         mock_notification_logger.info.assert_called_once_with("No AMQP URL specified")
 
@@ -29,7 +29,7 @@ class NotificationSendingTests(TestCase):
         notification.send_operational_update_message(
             flight_declaration_id="0001",
             message_text="Test Message",
-            level=NotificationLevel.INFO,
+            level=NotificationLevel.INFO.value,
         )
         mock_notification_logger.info.assert_called_once_with("No log message provided")
 
@@ -41,7 +41,7 @@ class NotificationSendingTests(TestCase):
         notification.send_operational_update_message(
             flight_declaration_id="0001",
             message_text="Test Message",
-            level=NotificationLevel.ERROR,
+            level=NotificationLevel.ERROR.value,
             log_message="This is a test log message",
         )
         mock_notification_logger.info.assert_called_once_with(
@@ -54,7 +54,7 @@ class NotificationSendingTests(TestCase):
         notification.send_operational_update_message(
             flight_declaration_id="0001",
             message_text="Test Message",
-            level=NotificationLevel.ERROR,
+            level=NotificationLevel.ERROR.value,
             timestamp="Test time string",
             log_message="This is a test log message",
         )
@@ -72,7 +72,7 @@ class NotificationSendingTests(TestCase):
         notification.send_operational_update_message(
             flight_declaration_id="0001",
             message_text="Test Message",
-            level=NotificationLevel.CRITICAL,
+            level=NotificationLevel.CRITICAL.value,
             timestamp="Test time string",
             log_message="This is a test log message",
         )


### PR DESCRIPTION
## Proposed changes

Celery fails serialize the enum NotificationMessage when constructing a message payload to the messaging queue. Hence changing the `level`  attribute's type from `NotificationMessage` to `str`

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with the changes
- [ ] Added new tests that prove the changes in this PR works
- [ ] Added necessary documentation (if appropriate)
- [ ] Added copyrights to new files (if appropriate)

## Further comments

_Add special comments about the changes here if required._